### PR TITLE
[IOX#3] Fix typos, repair links and comment-out Debian package usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ so he can stream his favorite [video](https://www.youtube.com/watch?v=g5NkgZXWl0
 
 ## Download
 
+<!--
 Either download our pre-built daemon (called RouDi) and our runtime lib or build everything yourself.
 
 ### Release
@@ -61,6 +62,7 @@ Either download our pre-built daemon (called RouDi) and our runtime lib or build
     dpkg -i iceoryx.deb
 
 You've sucessfully installed iceoryx! Continue with the section examples to see how to get started developing applications using iceoryx.
+-->
 
 ### Development
 
@@ -81,7 +83,7 @@ iceoryx_utils and iceoryx_posh are deployed as independent cmake packages. Posh 
 For the first start we advise to use our build-test script for building everything.
 
     git clone https://github.com/eclipse/iceoryx.git
-    ./tools/iceoryx_build-test.sh
+    ./tools/iceoryx_build_test.sh
 
 In default-mode the script is not building the provided test. For a clean build just add "clean" as first argument to the script.
 
@@ -89,7 +91,7 @@ In default-mode the script is not building the provided test. For a clean build 
 
 To build iceoryx with tests, just add "test" as first argument to the script.
 
-    ./tools/iceoryx_build-test.sh test
+    ./tools/iceoryx_build_test.sh test
 
 The Googletest-Framework will be automatically fetched from github and the test will be executed and the end of the script.
 
@@ -97,13 +99,13 @@ Congrats! You've build all the necessary things to continue playing around with 
 
 ## Examples
 
-Great that your still here, time for code! The following examples give you a quick and easy introduction into the inner
+Great that you're still here, time for code! The following examples give you a quick and easy introduction into the inner
 workings of iceoryx. We hope you enjoy our sightseeing tour!
 
 |Name | Description | Technologies |
 |---|---|---|
-| [icedelivery](./examples/icedelivery) | Transfer data between POSIX applications | [SoA](https://en.wikipedia.org/wiki/Service-oriented_architecture), service description |
-| [ros-on-ice](http://link.to.ros.implementation) | See how iceoryx can be used inside the robot operating system (will come) | ROS, RMW |
+| [icedelivery](./iceoryx_examples/icedelivery) | Transfer data between POSIX applications | [SoA](https://en.wikipedia.org/wiki/Service-oriented_architecture), service description |
+| [rmw_iceoryx](https://github.com/ros2/rmw_iceoryx) | See how iceoryx can be used inside the robot operating system | ROS, RMW |
 
 Is something missing or you've got ideas for other nifty examples? Jump right away to the next section!
 

--- a/iceoryx_examples/README.md
+++ b/iceoryx_examples/README.md
@@ -1,6 +1,7 @@
 # Building the examples
 
-A warm welcome to iceoryx examples Readme! You can build all the example either by using the Debian package or
+A warm welcome to iceoryx examples Readme!
+<!-- You can build all the example either by using the Debian package or
 build things from scratch.
 
 ## Debian package
@@ -11,13 +12,15 @@ the examples, do the following:
     ./iceexample#          mkdir build && cd build
     ./iceexample/build#    cmake ..
     ./iceexample/build#    cmake --build .
+-->
 
 ## Build everything from source
 
 When building all the bits from source, build RouDi and the runtime as described in the main
-[Readme.md](../README.md#user-content-development) with `./tools/iceoryx_build-test.sh`. Just add the path of the
-`build` directory:
+[Readme.md](../README.md#user-content-development) with `./tools/iceoryx_build_test.sh`. All examples are automatically
+built when using the script. If you want to build one example standalone add the path of the `build` directory when
+calling `cmake` after you have run the script:
 
     ./iceexample#          mkdir build && cd build
-    ./iceexample/build#    cmake .. -DCMAKE_INSTALL_PREFIX="`pwd`/../../../build/"
+    ./iceexample/build#    cmake .. -DCMAKE_INSTALL_PREFIX="`pwd`/../../../build/install/prefix"
     ./iceexample/build#    cmake --build .


### PR DESCRIPTION
- Fix Debian release link
- Fix example links $ROOT/README.md
- Fix typo in $ROOT/README.md "Great that your still here"
- Fix typo in $ROOT/README.md "./tools/iceoryx_build - test.sh
- Fix description for examples $ROOT/iceoryx_examples/README.md


Signed-off-by: Hoinkis Simon (CC-AD/ESW1) <simon.hoinkis2@de.bosch.com>