### PR TITLE
Minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Altough we strive to be fully POSIX-compliant, we recommend to use Ubuntu 18.04 
 
 You will need to install the following packages:
 
-    sudo apt-get install cmake libacl1-dev libncurses5-dev pkg-config
+    sudo apt install cmake libacl1-dev libncurses5-dev pkg-config
 
 #### Build from sources
 

--- a/iceoryx_posh/source/popo/subscriber.cpp
+++ b/iceoryx_posh/source/popo/subscriber.cpp
@@ -103,8 +103,8 @@ void Subscriber::setReceiveHandler(ReceiveHandler_t cbHandler) noexcept
 // name thread if possible
 #ifdef __unix__
     char threadname[16];
-    static ushort thread_index = 0;
-    snprintf(threadname, sizeof(threadname), "receiver-cb_%d", ++thread_index);
+    static uint16_t thread_index = 0;
+    snprintf(threadname, sizeof(threadname), "Receive_%d", ++thread_index);
     auto thread_handle = m_callbackThread.native_handle();
     pthread_setname_np(thread_handle, threadname); // thread name restricted to 16 chars
 // (incl. '0') but name buffer needs to be at least 16 chars

--- a/iceoryx_utils/include/iceoryx_utils/fixed_string/string100.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/fixed_string/string100.hpp
@@ -44,7 +44,7 @@ class CString100
     CString100(const char* const cstring, const uint64_t length);
 
     CString100(const std::string& str);
-    ~CString100();
+    ~CString100() = default;
 
     //! Assignment operator.
     CString100& operator=(const CString100& str2);
@@ -57,7 +57,7 @@ class CString100
     // >0  the first character that does not match has a greater value in str1 than in str2
     int32_t compare(const CString100& str2) const;
 
-    uint capacity() const;
+    uint64_t capacity() const;
 
     const char* to_cstring() const;
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/smart_lock.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/smart_lock.hpp
@@ -69,7 +69,7 @@ class smart_lock
     smart_lock(smart_lock&& rhs);
     smart_lock& operator=(const smart_lock& rhs);
     smart_lock& operator=(smart_lock&& rhs);
-    ~smart_lock();
+    ~smart_lock() = default;
 
     /// @brief The arrow operator returns a proxy object which locks the mutex
     ///         of smart_lock and has another arrow operator defined which

--- a/iceoryx_utils/include/iceoryx_utils/internal/concurrent/smart_lock.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/concurrent/smart_lock.inl
@@ -50,11 +50,6 @@ smart_lock<T, MutexType>::smart_lock(smart_lock&& rhs)
 }
 
 template <typename T, typename MutexType>
-smart_lock<T, MutexType>::~smart_lock()
-{
-}
-
-template <typename T, typename MutexType>
 smart_lock<T, MutexType>& smart_lock<T, MutexType>::operator=(const smart_lock& rhs)
 {
     std::lock(lock, rhs.lock);

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/vector.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/vector.inl
@@ -201,7 +201,7 @@ inline const T& vector<T, Capacity>::at(const uint64_t index) const
 {
     if (index + 1 > m_size)
     {
-        fprintf(stderr, "out of bounds access, current size is %lu but given index is %lu\n", m_size, index);
+        std::cerr << "out of bounds access, current size is " << m_size <<  " but given index is " << index << std::endl;
         std::terminate();
     }
     return reinterpret_cast<const T*>(m_data)[index];

--- a/iceoryx_utils/include/iceoryx_utils/internal/file_reader/file_reader.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/file_reader/file_reader.hpp
@@ -58,7 +58,7 @@ class FileReader
     FileReader& operator=(const FileReader&) = delete;
     FileReader& operator=(FileReader&&) = delete;
 
-    ~FileReader();
+    ~FileReader() = default;
 
     /// Check if the associated file is open.
     bool IsOpen() const;

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/access_control.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/access_control.hpp
@@ -44,7 +44,7 @@ class AccessController
     static constexpr int32_t MaxNumOfPermissions = 20;
 
     /// @brief identifier for a permission entry (user, group, others, ...)
-    enum class Category
+    enum class Category : acl_tag_t
     {
         USER = ACL_USER_OBJ,
         /// a specific user must be identified by a name
@@ -56,11 +56,11 @@ class AccessController
     };
 
     /// @brief access right for a permission entry
-    enum class Permission
+    enum class Permission : acl_perm_t
     {
         READ = ACL_READ,
         WRITE = ACL_WRITE,
-        READWRITE = ACL_READ | ACL_WRITE,
+        READWRITE = Permission::READ | Permission::WRITE,
         NONE = 0
     };
 
@@ -84,7 +84,7 @@ class AccessController
     bool writePermissionsToFile(const int f_fileDescriptor) const;
 
   private:
-    using smartAclPointer_t = std::unique_ptr<struct __acl_ext, std::function<void(struct __acl_ext*)>>;
+    using smartAclPointer_t = std::unique_ptr<std::remove_pointer<acl_t>::type, std::function<void(acl_t)>>;
 
     struct PermissionEntry
     {

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/shared_memory_object.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/shared_memory_object.hpp
@@ -42,7 +42,7 @@ class SharedMemoryObject
     SharedMemoryObject& operator=(const SharedMemoryObject&) = delete;
     SharedMemoryObject(SharedMemoryObject&&) = default;
     SharedMemoryObject& operator=(SharedMemoryObject&&) = default;
-    ~SharedMemoryObject();
+    ~SharedMemoryObject() = default;
 
     void* allocate(const uint64_t f_size, const uint64_t f_alignment = Allocator::MEMORY_ALIGNMENT);
     void finalizeAllocation();

--- a/iceoryx_utils/source/file_reader/file_reader.cpp
+++ b/iceoryx_utils/source/file_reader/file_reader.cpp
@@ -54,10 +54,6 @@ FileReader::FileReader(const std::string& f_fileName, const std::string& f_fileP
     }
 }
 
-FileReader::~FileReader()
-{
-}
-
 bool FileReader::IsOpen() const
 {
     return m_fileStream.is_open();

--- a/iceoryx_utils/source/fixed_string/string100.cpp
+++ b/iceoryx_utils/source/fixed_string/string100.cpp
@@ -63,10 +63,6 @@ CString100::CString100(const std::string& str)
 {
 }
 
-CString100::~CString100()
-{
-}
-
 //! Assignment operator.
 CString100& CString100::operator=(const CString100& str2)
 {
@@ -100,7 +96,7 @@ int32_t CString100::compare(const CString100& str2) const
     return strncmp(m_string_vector.data(), str2.m_string_vector.data(), MaxStringSize);
 }
 
-uint CString100::capacity() const
+uint64_t CString100::capacity() const
 {
     return MaxStringSize;
 }

--- a/iceoryx_utils/source/posix_wrapper/access_control.cpp
+++ b/iceoryx_utils/source/posix_wrapper/access_control.cpp
@@ -82,7 +82,7 @@ AccessController::smartAclPointer_t AccessController::createACL(const int f_numE
     }
 
     // define how to free the memory (custom deleter for the smart pointer)
-    std::function<void(struct __acl_ext*)> freeACL = [&](struct __acl_ext* acl) {
+    std::function<void(acl_t)> freeACL = [&](acl_t acl) {
         auto aclFreeCall = cxx::makeSmartC(acl_free, cxx::ReturnMode::PRE_DEFINED_SUCCESS_CODE, {0}, {}, acl);
         if (aclFreeCall.hasErrors())
         {
@@ -91,7 +91,7 @@ AccessController::smartAclPointer_t AccessController::createACL(const int f_numE
         }
     };
 
-    return smartAclPointer_t(reinterpret_cast<struct __acl_ext*>(aclInitCall.getReturnValue()), freeACL);
+    return smartAclPointer_t(reinterpret_cast<acl_t>(aclInitCall.getReturnValue()), freeACL);
 }
 
 bool AccessController::addPermissionEntry(const Category f_category,

--- a/iceoryx_utils/source/posix_wrapper/shared_memory_object.cpp
+++ b/iceoryx_utils/source/posix_wrapper/shared_memory_object.cpp
@@ -86,11 +86,6 @@ SharedMemoryObject::SharedMemoryObject(const char* f_name,
     }
 }
 
-SharedMemoryObject::~SharedMemoryObject()
-{
-}
-
-
 void* SharedMemoryObject::allocate(const uint64_t f_size, const uint64_t f_alignment)
 {
     return m_allocator.allocate(f_size, f_alignment);


### PR DESCRIPTION
1. Make subscriber thread name shorter to prevent truncation of format string
2. Replace use of ushort, uint with more explicit types
3. Use default destructors where appropriate
4. Use std::cerr instead of fprintf
5. Make ACL enum classes extend actual underlying numeric types
6. Use std::remove_pointer<acl_t>:: type instead of implementation-dependent __acl_ext
7. Switch instructions from apt-get to the more friendly apt
