### PR TITLE
fix qnx build

### DIFF
--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/access_control.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/access_control.hpp
@@ -43,8 +43,12 @@ class AccessController
     /// @brief maximum number of permission entries the AccessController can store
     static constexpr int32_t MaxNumOfPermissions = 20;
 
-    /// @brief identifier for a permission entry (user, group, others, ...)
+/// @brief identifier for a permission entry (user, group, others, ...)
+#if defined(QNX) || defined(QNX__) || defined(__QNX__)
+    enum class Category : std::underlying_type(acl_tag_t)
+#else
     enum class Category : acl_tag_t
+#endif
     {
         USER = ACL_USER_OBJ,
         /// a specific user must be identified by a name
@@ -55,8 +59,12 @@ class AccessController
         OTHERS = ACL_OTHER,
     };
 
-    /// @brief access right for a permission entry
+/// @brief access right for a permission entry
+#if defined(QNX) || defined(QNX__) || defined(__QNX__)
+    enum class Permission : std::underlying_type(acl_perm_t)
+#else
     enum class Permission : acl_perm_t
+#endif
     {
         READ = ACL_READ,
         WRITE = ACL_WRITE,


### PR DESCRIPTION
the ACL types on QNX are different from the ones on linux, therefore this conditional compilation for the AccessController enums