### PR TITLE
IOX-#12 32-bit support - fixing alignment problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Examples for a "porcelain" API would be e.g.
 [Adaptive Autosar Foundation](https://www.autosar.org/fileadmin/Releases_TEMP/Adaptive_Platform_19-03/AdaptiveFoundation.zip)
 (see AUTOSAR_EXP_ARAComAPI.pdf) or [ROS](https://www.ros.org).
 
+### Supported Platforms
+
+ * Linux
+ * QNX
+ * macOS (not yet - currently in progress with high priority)
+ * Windows 10 (not yet - currently in progress)
+
 ### Scope
 
 Who can benefit of using iceoryx? What's in for those folks?

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -56,6 +56,7 @@ constexpr uint32_t MAX_INTERFACE_CAPRO_FIFO_SIZE = MAX_PORT_NUMBER;
 constexpr uint32_t MAX_APPLICATION_CAPRO_FIFO_SIZE = 128;
 
 // Memory
+constexpr uint64_t SHARED_MEMORY_ALIGNMENT = 32;
 constexpr uint32_t MAX_NUMBER_OF_MEMPOOLS = 32;
 constexpr uint32_t MAX_SHM_SEGMENTS = 100;
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.inl
@@ -162,7 +162,7 @@ uint64_t SegmentManager<SegmentType>::requiredManagementMemorySize(const RouDiCo
     uint64_t memorySize{0};
     for (auto segment : f_config.m_sharedMemorySegments)
     {
-        memorySize += cxx::align(MemoryManager::requiredManagementMemorySize(segment.m_mempoolConfig), 32ul);
+        memorySize += cxx::align(MemoryManager::requiredManagementMemorySize(segment.m_mempoolConfig), SHARED_MEMORY_ALIGNMENT);
     }
     return memorySize;
 }
@@ -173,7 +173,7 @@ uint64_t SegmentManager<SegmentType>::requiredChunkMemorySize(const RouDiConfig_
     uint64_t memorySize{0};
     for (auto segment : f_config.m_sharedMemorySegments)
     {
-        memorySize += cxx::align(MemoryManager::requiredChunkMemorySize(segment.m_mempoolConfig), 32ul);
+        memorySize += cxx::align(MemoryManager::requiredChunkMemorySize(segment.m_mempoolConfig), SHARED_MEMORY_ALIGNMENT);
     }
     return memorySize;
 }
@@ -181,7 +181,7 @@ uint64_t SegmentManager<SegmentType>::requiredChunkMemorySize(const RouDiConfig_
 template <typename SegmentType>
 uint64_t SegmentManager<SegmentType>::requiredFullMemorySize(const RouDiConfig_t& f_config)
 {
-    return cxx::align(requiredManagementMemorySize(f_config) + requiredChunkMemorySize(f_config), 32ul);
+    return cxx::align(requiredManagementMemorySize(f_config) + requiredChunkMemorySize(f_config), SHARED_MEMORY_ALIGNMENT);
 }
 
 } // namespace mepoo

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/typed_mem_pool.inl
@@ -82,7 +82,7 @@ template <typename T>
 uint64_t TypedMemPool<T>::requiredManagementMemorySize(const uint64_t f_numberOfChunks)
 {
     return f_numberOfChunks * sizeof(ChunkManagement)
-           + 2 * cxx::align(MemPool::freeList_t::requiredMemorySize(f_numberOfChunks), 32ul);
+           + 2 * cxx::align(static_cast<uint64_t>(MemPool::freeList_t::requiredMemorySize(f_numberOfChunks)), SHARED_MEMORY_ALIGNMENT);
 }
 
 template <typename T>

--- a/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_creator.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/runtime/shared_memory_creator.inl
@@ -40,13 +40,13 @@ inline SharedMemoryCreator<ShmType>::SharedMemoryCreator(const RouDiConfig_t& co
     /// @todo these are internal mempool for the introspection, move to a better place
     mepoo::MePooConfig mempoolConfig;
     mempoolConfig.m_mempoolConfig.push_back(
-        {static_cast<uint32_t>(cxx::align(sizeof(roudi::MemPoolIntrospectionTopic), 32ul)), 250});
+        {static_cast<uint32_t>(cxx::align(static_cast<uint64_t>(sizeof(roudi::MemPoolIntrospectionTopic)), SHARED_MEMORY_ALIGNMENT)), 250});
     mempoolConfig.m_mempoolConfig.push_back(
-        {static_cast<uint32_t>(cxx::align(sizeof(roudi::ProcessIntrospectionFieldTopic), 32ul)), 10});
+        {static_cast<uint32_t>(cxx::align(static_cast<uint64_t>(sizeof(roudi::ProcessIntrospectionFieldTopic)), SHARED_MEMORY_ALIGNMENT)), 10});
     mempoolConfig.m_mempoolConfig.push_back(
-        {static_cast<uint32_t>(cxx::align(sizeof(roudi::PortIntrospectionFieldTopic), 32ul)), 10});
+        {static_cast<uint32_t>(cxx::align(static_cast<uint64_t>(sizeof(roudi::PortIntrospectionFieldTopic)), SHARED_MEMORY_ALIGNMENT)), 10});
     mempoolConfig.m_mempoolConfig.push_back(
-        {static_cast<uint32_t>(cxx::align(sizeof(roudi::PortThroughputIntrospectionFieldTopic), 32ul)), 10});
+        {static_cast<uint32_t>(cxx::align(static_cast<uint64_t>(sizeof(roudi::PortThroughputIntrospectionFieldTopic)), SHARED_MEMORY_ALIGNMENT)), 10});
     mempoolConfig.optimize();
 
     uint64_t totalSharedMemorySize = ShmType::getRequiredSharedMemory()

--- a/iceoryx_posh/source/mepoo/memory_manager.cpp
+++ b/iceoryx_posh/source/mepoo/memory_manager.cpp
@@ -124,11 +124,11 @@ uint64_t MemoryManager::requiredManagementMemorySize(const MePooConfig& f_mePooC
     for (const auto& mempool : f_mePooConfig.m_mempoolConfig)
     {
         sumOfAllChunks += mempool.m_chunkCount;
-        memorySize += cxx::align(MemPool::freeList_t::requiredMemorySize(mempool.m_chunkCount), 32ul);
+        memorySize += cxx::align(static_cast<uint64_t>(MemPool::freeList_t::requiredMemorySize(mempool.m_chunkCount)), SHARED_MEMORY_ALIGNMENT);
     }
 
     memorySize += sumOfAllChunks * sizeof(ChunkManagement);
-    memorySize += cxx::align(MemPool::freeList_t::requiredMemorySize(sumOfAllChunks), 32ul);
+    memorySize += cxx::align(static_cast<uint64_t>(MemPool::freeList_t::requiredMemorySize(sumOfAllChunks)), SHARED_MEMORY_ALIGNMENT);
 
     return memorySize;
 }

--- a/iceoryx_utils/CMakeLists.txt
+++ b/iceoryx_utils/CMakeLists.txt
@@ -168,13 +168,8 @@ target_compile_options(iceoryx_utils PUBLIC -std=c++11)
 target_compile_options(iceoryx_utils PUBLIC -fPIC)
 
 if(NOT CMAKE_SYSTEM_NAME MATCHES QNX)
-    target_link_libraries(iceoryx_utils PRIVATE acl ${CODE_COVERAGE_LIBS})
+    target_link_libraries(iceoryx_utils PRIVATE acl atomic rt ${CODE_COVERAGE_LIBS})
 endif(NOT CMAKE_SYSTEM_NAME MATCHES QNX)
-
-if(NOT CMAKE_SYSTEM_NAME MATCHES QNX)
-    target_link_libraries(iceoryx_utils PRIVATE rt)
-endif(NOT CMAKE_SYSTEM_NAME MATCHES QNX)
-
 
 set_target_properties(iceoryx_utils
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"

--- a/iceoryx_utils/include/iceoryx_utils/cxx/convert.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/convert.hpp
@@ -21,6 +21,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <sstream>
 #include <string>
 

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/convert.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/convert.inl
@@ -104,18 +104,15 @@ inline bool convert::stringIsNumberWithErrorMessage(const char* v, const NumberT
         std::cerr << v << " is not ";
         switch (type)
         {
-        case NumberType::FLOAT:
-        {
+        case NumberType::FLOAT: {
             std::cerr << "a float";
             break;
         }
-        case NumberType::INTEGER:
-        {
+        case NumberType::INTEGER: {
             std::cerr << "a signed integer";
             break;
         }
-        case NumberType::UNSIGNED_INTEGER:
-        {
+        case NumberType::UNSIGNED_INTEGER: {
             std::cerr << "an unsigned integer";
             break;
         }
@@ -184,97 +181,7 @@ inline bool convert::fromString<long double>(const char* v, long double& dest)
 }
 
 template <>
-inline bool convert::fromString<unsigned int>(const char* v, unsigned int& dest)
-{
-    if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
-    {
-        return false;
-    }
-
-    auto call = makeSmartC(strtoul, ReturnMode::PRE_DEFINED_ERROR_CODE, {ULONG_MAX}, {}, v, nullptr, 10);
-    if (call.hasErrors())
-    {
-        return false;
-    }
-
-    if (call.getReturnValue() > UINT_MAX)
-    {
-        std::cerr << call.getReturnValue() << " too large, unsigned integer overflow" << std::endl;
-        return false;
-    }
-
-    dest = static_cast<unsigned int>(call.getReturnValue());
-    return true;
-}
-
-template <>
-inline bool convert::fromString<unsigned short>(const char* v, unsigned short& dest)
-{
-    if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
-    {
-        return false;
-    }
-
-    auto call = makeSmartC(strtoul, ReturnMode::PRE_DEFINED_ERROR_CODE, {ULONG_MAX}, {}, v, nullptr, 10);
-    if (call.hasErrors())
-    {
-        return false;
-    }
-
-    if (call.getReturnValue() > USHRT_MAX)
-    {
-        std::cerr << call.getReturnValue() << " too large, unsigned short overflow" << std::endl;
-        return false;
-    }
-
-    dest = static_cast<unsigned short>(call.getReturnValue());
-    return true;
-}
-
-template <>
-inline bool convert::fromString<short>(const char* v, short& dest)
-{
-    if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
-    {
-        return false;
-    }
-
-    auto call = makeSmartC(strtol, ReturnMode::PRE_DEFINED_ERROR_CODE, {LONG_MAX, LONG_MIN}, {}, v, nullptr, 10);
-    if (call.hasErrors())
-    {
-        return false;
-    }
-
-    if (call.getReturnValue() > SHRT_MAX || call.getReturnValue() < SHRT_MIN)
-    {
-        std::cerr << call.getReturnValue() << " too large, short integer overflow" << std::endl;
-        return false;
-    }
-
-    dest = static_cast<short>(call.getReturnValue());
-    return true;
-}
-
-template <>
-inline bool convert::fromString<unsigned long>(const char* v, unsigned long& dest)
-{
-    if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
-    {
-        return false;
-    }
-
-    auto call = makeSmartC(strtoul, ReturnMode::PRE_DEFINED_ERROR_CODE, {ULONG_MAX}, {}, v, nullptr, 10);
-    if (call.hasErrors())
-    {
-        return false;
-    }
-
-    dest = call.getReturnValue();
-    return true;
-}
-
-template <>
-inline bool convert::fromString<unsigned long long>(const char* v, unsigned long long& dest)
+inline bool convert::fromString<uint64_t>(const char* v, uint64_t& dest)
 {
     if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
     {
@@ -287,54 +194,90 @@ inline bool convert::fromString<unsigned long long>(const char* v, unsigned long
         return false;
     }
 
-    dest = call.getReturnValue();
+    if (call.getReturnValue() > std::numeric_limits<uint64_t>::max())
+    {
+        std::cerr << call.getReturnValue() << " too large, uint64_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<uint64_t>(call.getReturnValue());
     return true;
 }
 
 template <>
-inline bool convert::fromString<int>(const char* v, int& dest)
+inline bool convert::fromString<uint32_t>(const char* v, uint32_t& dest)
 {
-    if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
+    if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
     {
         return false;
     }
 
-    auto call = makeSmartC(strtol, ReturnMode::PRE_DEFINED_ERROR_CODE, {LONG_MAX, LONG_MIN}, {}, v, nullptr, 10);
+    auto call = makeSmartC(strtoull, ReturnMode::PRE_DEFINED_ERROR_CODE, {ULLONG_MAX}, {}, v, nullptr, 10);
     if (call.hasErrors())
     {
         return false;
     }
 
-    if (call.getReturnValue() < INT_MIN || call.getReturnValue() > INT_MAX)
+    if (call.getReturnValue() > std::numeric_limits<uint32_t>::max())
     {
-        std::cerr << call.getReturnValue() << " too large, integer overflow!" << std::endl;
+        std::cerr << call.getReturnValue() << " too large, uint32_t overflow" << std::endl;
         return false;
     }
 
-    dest = static_cast<int>(call.getReturnValue());
+    dest = static_cast<uint32_t>(call.getReturnValue());
     return true;
 }
 
 template <>
-inline bool convert::fromString<long>(const char* v, long& dest)
+inline bool convert::fromString<uint16_t>(const char* v, uint16_t& dest)
 {
-    if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
+    if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
     {
         return false;
     }
 
-    auto call = makeSmartC(strtol, ReturnMode::PRE_DEFINED_ERROR_CODE, {LONG_MAX, LONG_MIN}, {}, v, nullptr, 10);
+    auto call = makeSmartC(strtoul, ReturnMode::PRE_DEFINED_ERROR_CODE, {ULONG_MAX}, {}, v, nullptr, 10);
     if (call.hasErrors())
     {
         return false;
     }
 
-    dest = call.getReturnValue();
+    if (call.getReturnValue() > std::numeric_limits<uint16_t>::max())
+    {
+        std::cerr << call.getReturnValue() << " too large, uint16_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<uint16_t>(call.getReturnValue());
     return true;
 }
 
 template <>
-inline bool convert::fromString<long long>(const char* v, long long& dest)
+inline bool convert::fromString<uint8_t>(const char* v, uint8_t& dest)
+{
+    if (!stringIsNumberWithErrorMessage(v, NumberType::UNSIGNED_INTEGER))
+    {
+        return false;
+    }
+
+    auto call = makeSmartC(strtoul, ReturnMode::PRE_DEFINED_ERROR_CODE, {ULONG_MAX}, {}, v, nullptr, 10);
+    if (call.hasErrors())
+    {
+        return false;
+    }
+
+    if (call.getReturnValue() > std::numeric_limits<uint8_t>::max())
+    {
+        std::cerr << call.getReturnValue() << " too large, uint8_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<uint8_t>(call.getReturnValue());
+    return true;
+}
+
+template <>
+inline bool convert::fromString<int64_t>(const char* v, int64_t& dest)
 {
     if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
     {
@@ -347,7 +290,89 @@ inline bool convert::fromString<long long>(const char* v, long long& dest)
         return false;
     }
 
-    dest = call.getReturnValue();
+    if (call.getReturnValue() > std::numeric_limits<int64_t>::max()
+        || call.getReturnValue() < std::numeric_limits<int64_t>::min())
+    {
+        std::cerr << call.getReturnValue() << " is out of range, int64_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<int64_t>(call.getReturnValue());
+    return true;
+}
+
+template <>
+inline bool convert::fromString<int32_t>(const char* v, int32_t& dest)
+{
+    if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
+    {
+        return false;
+    }
+
+    auto call = makeSmartC(strtoll, ReturnMode::PRE_DEFINED_ERROR_CODE, {LLONG_MAX, LLONG_MIN}, {}, v, nullptr, 10);
+    if (call.hasErrors())
+    {
+        return false;
+    }
+
+    if (call.getReturnValue() > std::numeric_limits<int32_t>::max()
+        || call.getReturnValue() < std::numeric_limits<int32_t>::min())
+    {
+        std::cerr << call.getReturnValue() << " is out of range, int32_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<int32_t>(call.getReturnValue());
+    return true;
+}
+
+template <>
+inline bool convert::fromString<int16_t>(const char* v, int16_t& dest)
+{
+    if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
+    {
+        return false;
+    }
+
+    auto call = makeSmartC(strtol, ReturnMode::PRE_DEFINED_ERROR_CODE, {LONG_MAX, LONG_MIN}, {}, v, nullptr, 10);
+    if (call.hasErrors())
+    {
+        return false;
+    }
+
+    if (call.getReturnValue() > std::numeric_limits<int16_t>::max()
+        || call.getReturnValue() < std::numeric_limits<int16_t>::min())
+    {
+        std::cerr << call.getReturnValue() << " is out of range, int16_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<int16_t>(call.getReturnValue());
+    return true;
+}
+
+template <>
+inline bool convert::fromString<int8_t>(const char* v, int8_t& dest)
+{
+    if (!stringIsNumberWithErrorMessage(v, NumberType::INTEGER))
+    {
+        return false;
+    }
+
+    auto call = makeSmartC(strtol, ReturnMode::PRE_DEFINED_ERROR_CODE, {LONG_MAX, LONG_MIN}, {}, v, nullptr, 10);
+    if (call.hasErrors())
+    {
+        return false;
+    }
+
+    if (call.getReturnValue() > std::numeric_limits<int8_t>::max()
+        || call.getReturnValue() < std::numeric_limits<int8_t>::min())
+    {
+        std::cerr << call.getReturnValue() << " is out of range, int8_t overflow" << std::endl;
+        return false;
+    }
+
+    dest = static_cast<int8_t>(call.getReturnValue());
     return true;
 }
 

--- a/iceoryx_utils/source/posix_wrapper/shared_memory_object/allocator.cpp
+++ b/iceoryx_utils/source/posix_wrapper/shared_memory_object/allocator.cpp
@@ -41,7 +41,7 @@ void* Allocator::allocate(const uint64_t f_size, const uint64_t f_alignment)
     }
 
     uintptr_t l_currentAddress = reinterpret_cast<uintptr_t>(m_startAddress) + m_currentPosition;
-    uintptr_t l_alignedPosition = cxx::align(l_currentAddress, f_alignment);
+    uintptr_t l_alignedPosition = cxx::align(l_currentAddress, static_cast<uintptr_t>(f_alignment));
     l_alignedPosition -= reinterpret_cast<uintptr_t>(m_startAddress);
 
     byte_t* l_returnValue = nullptr;

--- a/iceoryx_utils/source/units/duration.cpp
+++ b/iceoryx_utils/source/units/duration.cpp
@@ -23,7 +23,7 @@ struct timespec Duration::timespec(const TimeSpecReference& reference) const
     switch (reference)
     {
     case TimeSpecReference::None:
-        return {this->seconds<long>(), this->nanoSeconds<long>() - this->seconds<long>() * 1000000000};
+        return {this->seconds<int>(), static_cast<int>(this->nanoSeconds<int64_t>() - this->seconds<int64_t>() * 1000000000)};
     default:
     {
         struct timespec referenceTime;

--- a/iceoryx_utils/test/moduletests/test_cxx_convert.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_convert.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "test.hpp"
 #include "iceoryx_utils/cxx/convert.hpp"
+#include "test.hpp"
 
 
 #include <cstdint>
@@ -211,7 +211,7 @@ TEST_F(convert_test, fromString_UNSIGNED_Int_Fail)
 TEST_F(convert_test, fromString_UNSIGNED_LongInt_Success)
 {
     std::string source = "123";
-    unsigned long int destination;
+    uint64_t destination;
     EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(true));
     EXPECT_THAT(destination, Eq(123lu));
 }
@@ -219,22 +219,7 @@ TEST_F(convert_test, fromString_UNSIGNED_LongInt_Success)
 TEST_F(convert_test, fromString_UNSIGNED_LongInt_Fail)
 {
     std::string source = "-a123";
-    unsigned long int destination;
-    EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(false));
-}
-
-TEST_F(convert_test, fromString_UNSIGNED_LongLongInt_Success)
-{
-    std::string source = "123";
-    unsigned long long int destination;
-    EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(true));
-    EXPECT_THAT(destination, Eq(123llu));
-}
-
-TEST_F(convert_test, fromString_UNSIGNED_LongLongInt_Fail)
-{
-    std::string source = "-a123";
-    unsigned long long int destination;
+    uint64_t destination;
     EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(false));
 }
 
@@ -301,7 +286,7 @@ TEST_F(convert_test, fromString_UShortInt_Fail)
 TEST_F(convert_test, fromString_LongInt_Success)
 {
     std::string source = "-1123";
-    long int destination;
+    int64_t destination;
     EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(true));
     EXPECT_THAT(destination, Eq(-1123l));
 }
@@ -309,22 +294,7 @@ TEST_F(convert_test, fromString_LongInt_Success)
 TEST_F(convert_test, fromString_LongInt_Fail)
 {
     std::string source = "-a123";
-    long int destination;
-    EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(false));
-}
-
-TEST_F(convert_test, fromString_LongLongInt_Success)
-{
-    std::string source = "-123";
-    long long int destination;
-    EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(true));
-    EXPECT_THAT(destination, Eq(-123ll));
-}
-
-TEST_F(convert_test, fromString_LongLongInt_Fail)
-{
-    std::string source = "-a123";
-    long long int destination;
+    int64_t destination;
     EXPECT_THAT(iox::cxx::convert::fromString(source.c_str(), destination), Eq(false));
 }
 

--- a/iceoryx_utils/test/moduletests/test_objectpool.cpp
+++ b/iceoryx_utils/test/moduletests/test_objectpool.cpp
@@ -106,6 +106,10 @@ class ObjectPool_test : public Test
     }
 
     FooPool pool;
+    int data;
+    int data1;
+    int data2;
+    int data3;
 };
 
 
@@ -219,7 +223,7 @@ TEST_F(ObjectPool_test, add)
     EXPECT_THAT(pool.capacity(), Eq(CAPACITY_UNSIGNED));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
 
-    int data = 0;
+    data = 0;
     for (int i = 1; i <= CAPACITY; ++i)
     {
         Foo foo(data);
@@ -248,14 +252,14 @@ TEST_F(ObjectPool_test, size_and_remove)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto index1 = pool.construct(data1);
     EXPECT_THAT(data1, Eq(1));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(1));
     EXPECT_THAT(Foo::getDestructionCounter(), Eq(0));
     EXPECT_THAT(pool.size(), Eq(1U));
 
-    int data2 = 0;
+    data2 = 0;
     Foo foo(data2);
     auto index2 = pool.add(foo);
     EXPECT_THAT(data2, Eq(2));
@@ -284,7 +288,7 @@ TEST_F(ObjectPool_test, bracket_operator)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto index1 = pool.construct(data1);
     EXPECT_THAT(data1, Eq(1));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(1));
@@ -292,7 +296,7 @@ TEST_F(ObjectPool_test, bracket_operator)
     EXPECT_THAT(pool.size(), Eq(1U));
     ASSERT_THAT(pool.get(index1), Ne(nullptr));
 
-    int data2 = 0;
+    data2 = 0;
     Foo foo(data2);
     auto index2 = pool.add(foo);
     EXPECT_THAT(data2, Eq(2));
@@ -353,7 +357,7 @@ TEST_F(ObjectPool_test, parameter_create)
     EXPECT_THAT(pool.capacity(), Eq(CAPACITY_UNSIGNED));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
 
-    int data = 0;
+    data = 0;
     for (int i = 1; i <= CAPACITY; ++i)
     {
         auto ptr = pool.create(data);
@@ -378,14 +382,14 @@ TEST_F(ObjectPool_test, destruct_free)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto ptr1 = pool.create(data1);
     EXPECT_THAT(data1, Eq(1));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(1));
     EXPECT_THAT(Foo::getDestructionCounter(), Eq(0));
     EXPECT_THAT(pool.size(), Eq(1U));
 
-    int data2 = 0;
+    data2 = 0;
     Foo foo(data2);
     auto ptr2 = pool.insert(foo);
     EXPECT_THAT(data2, Eq(2));
@@ -414,14 +418,14 @@ TEST_F(ObjectPool_test, default_free)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto ptr1 = pool.create(data1);
     EXPECT_THAT(data1, Eq(1));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(1));
     EXPECT_THAT(Foo::getDestructionCounter(), Eq(0));
     EXPECT_THAT(pool.size(), Eq(1U));
 
-    int data2 = 0;
+    data2 = 0;
     Foo foo(data2);
     auto ptr2 = pool.insert(foo);
     EXPECT_THAT(data2, Eq(2));
@@ -460,7 +464,7 @@ TEST_F(ObjectPool_test, insert)
     EXPECT_THAT(pool.capacity(), Eq(CAPACITY_UNSIGNED));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
 
-    int data = 0;
+    data = 0;
     for (int i = 1; i <= CAPACITY; ++i)
     {
         Foo foo(data);
@@ -487,14 +491,14 @@ TEST_F(ObjectPool_test, get)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto index1 = pool.construct(data1);
     EXPECT_THAT(data1, Eq(1));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(1));
     EXPECT_THAT(Foo::getDestructionCounter(), Eq(0));
     EXPECT_THAT(pool.size(), Eq(1U));
 
-    int data2 = 0;
+    data2 = 0;
     Foo foo(data2);
     auto ptr2 = pool.insert(foo);
     EXPECT_THAT(data2, Eq(2));
@@ -532,7 +536,7 @@ TEST_F(ObjectPool_test, pointerToIndexConversion)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto index1 = pool.construct(data1);
     EXPECT_THAT(data1, Eq(1));
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(1));
@@ -666,7 +670,7 @@ TEST_F(ObjectPool_test, destructor)
 
     Foo::resetConstructionCounter();
     Foo::resetDestructionCounter();
-    int data = 0;
+    data = 0;
 
     // default construction of Foo objects by pool
     {
@@ -705,7 +709,7 @@ TEST_F(ObjectPool_test, iterator)
     EXPECT_THAT(Foo::getConstructionCounter(), Eq(0)); // no Foo objects constructed by pool
     EXPECT_THAT(pool.size(), Eq(0U));
 
-    int data1 = 0;
+    data1 = 0;
     auto index1 = pool.construct(data1);
     EXPECT_THAT(index1, Ne(NO_INDEX));
     EXPECT_THAT(data1, Eq(1));
@@ -713,7 +717,7 @@ TEST_F(ObjectPool_test, iterator)
     EXPECT_THAT(Foo::getDestructionCounter(), Eq(0));
     EXPECT_THAT(pool.size(), Eq(1U));
 
-    int data2 = 0;
+    data2 = 0;
     auto index2 = pool.construct(data2);
     EXPECT_THAT(index2, Ne(NO_INDEX));
     EXPECT_THAT(data2, Eq(2));
@@ -721,7 +725,7 @@ TEST_F(ObjectPool_test, iterator)
     EXPECT_THAT(Foo::getDestructionCounter(), Eq(0));
     EXPECT_THAT(pool.size(), Eq(2U));
 
-    int data3 = 0;
+    data3 = 0;
     auto index3 = pool.construct(data3);
     EXPECT_THAT(index3, Ne(NO_INDEX));
     EXPECT_THAT(data3, Eq(3));


### PR DESCRIPTION
- fixed alignment problems in 32-bit mode
- duration rounding error in 32-bit fixed
- objectpool bug fixed which occurred only in 32-bit
- convert support for long long (unsigned) int is gone since long long cannot be supported in 32-bit
- 32-bit problems im memory management solved

Signed-off-by: Eltzschig Christian (CC-AD/ESW1) <christian.eltzschig2@de.bosch.com>