### PR TITLE
Fix variadic function build warning

### DIFF
--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -241,7 +241,7 @@ void IntrospectionApp::printProcessIntrospectionData(const ProcessIntrospectionF
 
     for (auto& data : processIntrospectionField->m_processList)
     {
-        wprintw(pad, "PID: %*d Process: %*s\n", pidWidth, data.m_pid, processWidth, data.m_name);
+        wprintw(pad, "PID: %*d Process: %*s\n", pidWidth, data.m_pid, processWidth, data.m_name.to_cstring());
     }
     wprintw(pad, "\n");
 }


### PR DESCRIPTION
```
/opt/ros/master/src/eclipse/iceoryx/tools/introspection/source/introspection_app.cpp:244:90: error: cannot pass object of non-trivial type 'const cxx::CString100' through variadic function; call will abort at runtime [-Wnon-pod-varargs]
        wprintw(pad, "PID: %*d Process: %*s\n", pidWidth, data.m_pid, processWidth, data.m_name);
                                                                                         ^
1 error generated.
make[2]: *** [CMakeFiles/iceoryx_introspection.dir/source/introspection_app.cpp.o] Error 1
make[1]: *** [CMakeFiles/iceoryx_introspection.dir/all] Error 2
make: *** [all] Error 2
---
Failed   <<< iceoryx_introspection	[ Exited with code 2 ]
```
