### PR TITLE
Fix operator mistake

### DIFF
--- a/iceoryx_utils/include/iceoryx_utils/posix_wrapper/timer.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/posix_wrapper/timer.hpp
@@ -84,7 +84,7 @@ class Timer
     class OsTimer;
     struct OsTimerCallbackHandle
     {
-        static constexpr uint32_t MAX_DESCRIPTOR_VALUE{(2 ^ 24) - 1};
+        static constexpr uint32_t MAX_DESCRIPTOR_VALUE{(1 << 24) - 1};
         static sigval indexAndDescriptorToSigval(uint8_t index, uint32_t descriptor);
         static uint8_t sigvalToIndex(sigval intVal);
         static uint32_t sigvalToDescriptor(sigval intVal);

--- a/iceoryx_utils/source/posix_wrapper/timer.cpp
+++ b/iceoryx_utils/source/posix_wrapper/timer.cpp
@@ -25,7 +25,6 @@ Timer::OsTimerCallbackHandle Timer::OsTimer::s_callbackHandlePool[MAX_NUMBER_OF_
 
 sigval Timer::OsTimerCallbackHandle::indexAndDescriptorToSigval(uint8_t index, uint32_t descriptor)
 {
-    // the max value of descriptor is 2^24 - 1;
     assert(descriptor < MAX_DESCRIPTOR_VALUE);
     uint32_t temp = (descriptor << 8) | static_cast<uint32_t>(index);
     sigval sigvalData;


### PR DESCRIPTION
Thanks, Clang!
```
--- stderr: iceoryx_utils
In file included from /opt/ros/master/src/eclipse/iceoryx/iceoryx_utils/source/posix_wrapper/timer.cpp:15:
/opt/ros/master/src/eclipse/iceoryx/iceoryx_utils/include/iceoryx_utils/posix_wrapper/timer.hpp:87:59: warning: result of '2 ^ 24' is 26; did you mean '1 << 24' (16777216)? [-Wxor-used-as-pow]
        static constexpr uint32_t MAX_DESCRIPTOR_VALUE{(2 ^ 24) - 1};
                                                        ~~^~~~
                                                        1 << 24
/opt/ros/master/src/eclipse/iceoryx/iceoryx_utils/include/iceoryx_utils/posix_wrapper/timer.hpp:87:59: note: replace expression with '0x2 ^ 24' or use 'xor' instead of '^' to silence this warning
1 warning generated.
```
