### PR TITLE
iox-#110 increase PROCESS_WAITING_FOR_ROUDI_TIMEOUT to 60s

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -40,7 +40,7 @@ constexpr char SHM_NAME[] = "/iceoryx_mgmt";
 using namespace units::duration_literals;
 
 // Timeout
-constexpr units::Duration PROCESS_WAITING_FOR_ROUDI_TIMEOUT = 30_s;
+constexpr units::Duration PROCESS_WAITING_FOR_ROUDI_TIMEOUT = 60_s;
 constexpr units::Duration DISCOVERY_INTERVAL = 100_ms;
 constexpr units::Duration PROCESS_KEEP_ALIVE_INTERVAL = 3 * DISCOVERY_INTERVAL;         // > DISCOVERY_INTERVAL
 constexpr units::Duration PROCESS_KEEP_ALIVE_TIMEOUT = 5 * PROCESS_KEEP_ALIVE_INTERVAL; // > PROCESS_KEEP_ALIVE_INTERVAL


### PR DESCRIPTION
Signed-off-by: Kraus Mathias (CC-AD/ESW1) <mathias.kraus2@de.bosch.com>