### PR TITLE
iox-#150 fix-destroy-method-of-message-queue-and-unix-domain-socket

### DIFF
--- a/iceoryx_utils/source/posix_wrapper/message_queue.cpp
+++ b/iceoryx_utils/source/posix_wrapper/message_queue.cpp
@@ -158,6 +158,7 @@ cxx::expected<IpcChannelError> MessageQueue::destroy()
     }
 
     m_mqDescriptor = INVALID_DESCRIPTOR;
+    m_isInitialized = false;
     return cxx::success<void>();
 }
 

--- a/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
+++ b/iceoryx_utils/source/posix_wrapper/unix_domain_socket.cpp
@@ -85,6 +85,7 @@ UnixDomainSocket& UnixDomainSocket::operator=(UnixDomainSocket&& other) noexcept
         m_sockAddr = std::move(other.m_sockAddr);
         other.m_sockfd = INVALID_FD;
         m_maxMessageSize = std::move(other.m_maxMessageSize);
+        moveCreationPatternValues(std::move(other));
     }
 
     return *this;
@@ -128,6 +129,7 @@ cxx::expected<IpcChannelError> UnixDomainSocket::destroy() noexcept
             }
 
             m_sockfd = INVALID_FD;
+            m_isInitialized = false;
 
             return cxx::success<void>();
         }

--- a/iceoryx_utils/test/moduletests/test_message_queue.cpp
+++ b/iceoryx_utils/test/moduletests/test_message_queue.cpp
@@ -214,6 +214,14 @@ TEST_F(MessageQueue_test, sendAndReceive)
     EXPECT_EQ(anotherMessage, *receivedMessage);
 }
 
+TEST_F(MessageQueue_test, invalidAfterDestroy)
+{
+    client.destroy();
+    ASSERT_FALSE(client.isInitialized());
+    server.destroy();
+    ASSERT_FALSE(server.isInitialized());
+}
+
 TEST_F(MessageQueue_test, sendAfterClientDestroy)
 {
     auto dest = client.destroy();


### PR DESCRIPTION
closes #150 

Signed-off-by: Kraus Mathias (CC-AD/ESW1) <mathias.kraus2@de.bosch.com>