### PR TITLE
iox-#157: fixed syntax error by adding a const cast

### DIFF
--- a/iceoryx_posh/source/popo/building_blocks/chunk_receiver.cpp
+++ b/iceoryx_posh/source/popo/building_blocks/chunk_receiver.cpp
@@ -46,7 +46,8 @@ cxx::expected<cxx::optional<const mepoo::ChunkHeader*>, ChunkReceiverError> Chun
         // if the application holds too many chunks, don't provide more
         if (getMembers()->m_chunksInUse.insert(sharedChunk))
         {
-            return cxx::success<cxx::optional<const mepoo::ChunkHeader*>>(sharedChunk.getChunkHeader());
+            return cxx::success<cxx::optional<const mepoo::ChunkHeader*>>(
+                const_cast<const mepoo::ChunkHeader*>(sharedChunk.getChunkHeader()));
         }
         else
         {


### PR DESCRIPTION
Signed-off-by: Christian Eltzschig <christian.eltzschig2@de.bosch.com>