### PR TITLE
make introspection compile on OSX

### DIFF
--- a/tools/introspection/CMakeLists.txt
+++ b/tools/introspection/CMakeLists.txt
@@ -59,18 +59,12 @@ target_link_libraries(iceoryx_introspection
 
 target_compile_options(iceoryx_introspection PRIVATE ${ICEORYX_WARNINGS})
 
-
-
 if(LINUX)
     set(LIB_TINFO tinfo)
-elseif(QNX)
-    set(LIB_TINFO "")
-elseif(APPLE)
-    find_library(LIB_TINFO tinfo)
 elseif(WIN32)
     message(WARNING "Introspection not supported for windows." )
 else()
-    message(WARNING "Could not detect supported platform, but I'm feeling lucky today." )
+    set(LIB_TINFO "")
 endif()
 
 target_link_libraries(iceoryx_introspection ${LIB_TINFO})

--- a/tools/introspection/CMakeLists.txt
+++ b/tools/introspection/CMakeLists.txt
@@ -83,11 +83,10 @@ target_link_libraries(iceoryx_introspection_client
 
 target_compile_options(iceoryx_introspection_client PRIVATE ${ICEORYX_WARNINGS})
 
-
 #
 ########## exporting library ##########
 #
 setup_install_directories_and_export_package(
-    TARGETS iceoryx_introspection
+    TARGETS iceoryx_introspection iceoryx_introspection_client
     INCLUDE_DIRECTORY include/
 )


### PR DESCRIPTION
fixes #175 

`ncurses` is available through `homebrew`, however `tinfo` isn't - It is also not needed though.
How did you test this in the past? I couldn't really find a way to make `tinfo` available on OSX.