### PR TITLE
Iox #221 apply cxx list

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/process_introspection.hpp
@@ -17,9 +17,9 @@
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/popo/sender_port.hpp"
 #include "iceoryx_posh/roudi/introspection_types.hpp"
+#include "iceoryx_utils/cxx/list.hpp"
 
 #include <atomic>
-#include <list>
 #include <mutex>
 #include <thread>
 
@@ -111,9 +111,7 @@ class ProcessIntrospection
     void setSendInterval(unsigned int interval_ms);
 
   private:
-    /// @todo use a fixed, stack based list once available
-    // using ProcessList_t = cxx::list<ProcessIntrospectionData, MAX_PROCESS_NUMBER>;
-    using ProcessList_t = std::list<ProcessIntrospectionData>;
+    using ProcessList_t = cxx::list<ProcessIntrospectionData, MAX_PROCESS_NUMBER>;
     ProcessList_t m_processList;
     bool m_processListNewData{true}; // true because we want to have a valid field, even with an empty list
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi_process.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi_process.hpp
@@ -23,12 +23,12 @@
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
 #include "iceoryx_posh/version/compatibility_check_level.hpp"
 #include "iceoryx_posh/version/version_info.hpp"
+#include "iceoryx_utils/cxx/list.hpp"
 #include "iceoryx_utils/posix_wrapper/posix_access_rights.hpp"
 
 #include <csignal>
 #include <cstdint>
 #include <ctime>
-#include <list>
 
 namespace iox
 {
@@ -100,9 +100,7 @@ class ProcessManagerInterface
 class ProcessManager : public ProcessManagerInterface
 {
   public:
-    /// @todo use a fixed, stack based list once available
-    // using ProcessList_t = cxx::list<RouDiProcess, MAX_PROCESS_NUMBER>;
-    using ProcessList_t = std::list<RouDiProcess>;
+    using ProcessList_t = cxx::list<RouDiProcess, MAX_PROCESS_NUMBER>;
     using PortConfigInfo = iox::runtime::PortConfigInfo;
 
     ProcessManager(RouDiMemoryInterface& roudiMemoryInterface,


### PR DESCRIPTION
Within the attached source std::list usage was removed from roudi process list handling (replaced with cxx::list implementation).
Additionally the FixedPositionContainer of roudi port pool was picked to replace with cxx::list as well... see details in #221. (fixes #221)

This PR requires cxx::list to be approved (merged) #215 first.