### PR TITLE
iox-#264 fix char array assignment to cxx::string

### DIFF
--- a/iceoryx_utils/README.md
+++ b/iceoryx_utils/README.md
@@ -52,7 +52,7 @@ class should be used.
 |`serialization`      |   | X | Implements a simple serialization concept for classes based on the idea presented here [ISOCPP serialization](https://isocpp.org/wiki/faq/serialization#serialize-text-format). |
 |`set`                | i | X | Templated helper functions to create a fake `std::set` from a vector. |
 |`smart_c`            |   |   | Wrapper around C and POSIX function calls which performs a full error handling. Additionally, this wrapper makes sure that `EINTR` handling is performed correctly by repeating the system call. |
-|`string`             |   |   | Heap and exception free implementation of `std::string`. |
+|`string`             |   |   | Heap and exception free implementation of `std::string`. Attention, since the string is stack based, std::string or char array which are assigned to this string will be truncated and zero-terminated if they exceed the string capacity. |
 |`types`              |   |   | Declares essential building block types like `byte_t`. |
 |`UniqueTypedID<T>`   |   |   | Provides a unique ids depending on the type. It does not provide a unique id for a type T! |
 |`variant`            |   |   | C++11 implementation of the C++17 feature `std::variant` |

--- a/iceoryx_utils/include/iceoryx_utils/cxx/string.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/string.hpp
@@ -70,6 +70,8 @@ class string
     /// @tparam N is the implicit template parameter for the char array size
     /// @param [in] other is the char array
     ///
+    /// @note if the array is not zero-terminated, the last value will be overwritten with 0
+    ///
     /// @code
     ///     #include "iceoryx_utils/cxx/string.hpp"
     ///     using namespace iox::cxx;
@@ -149,6 +151,8 @@ class string
     ///
     /// @return reference to self
     ///
+    /// @note if the array is not zero-terminated, the last value will be overwritten with 0
+    ///
     /// @code
     ///     #include "iceoryx_utils/cxx/string.hpp"
     ///     using namespace iox::cxx;
@@ -175,6 +179,9 @@ class string
     /// @param [in] str is the char array
     ///
     /// @return reference to self
+    ///
+    /// @note if the array is not zero-terminated, the last value will be overwritten with 0
+    ///
     /// @code
     ///
     ///     #include "iceoryx_utils/cxx/string.hpp"

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/string.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/string.inl
@@ -119,9 +119,17 @@ inline string<Capacity>& string<Capacity>::operator=(const char (&rhs)[N]) noexc
     {
         return *this;
     }
-    std::memcpy(m_rawstring, rhs, N - 1u);
-    m_rawstring[N - 1u] = '\0';
-    m_rawstringSize = N - 1u;
+
+    m_rawstringSize = strnlen(rhs, Capacity);
+    std::memcpy(m_rawstring, rhs, m_rawstringSize);
+    m_rawstring[m_rawstringSize] = '\0';
+
+    if (rhs[m_rawstringSize] != '\0')
+    {
+        std::cerr << "iox::cxx::string: Assignment of array which is not zero-terminated! Last value of array "
+                     "overwritten with 0!"
+                  << std::endl;
+    }
     return *this;
 }
 

--- a/iceoryx_utils/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_string.cpp
@@ -361,6 +361,23 @@ TEST(String100, UnsafeCharToStringConstrIncludingNullCharWithCountResultsInSizeC
     EXPECT_THAT(testSubject.c_str(), StrEq("ice\0ryx"));
 }
 
+TEST(CharArrayAssignment, AssignZeroTerminatedCharArrayOfSizeForFullCapa)
+{
+    char testString[8] = "iceoryx";
+    string<7> testSubject(testString);
+    EXPECT_THAT(testSubject.size(), Eq(7));
+    EXPECT_THAT(testSubject.c_str(), StrEq("iceoryx"));
+}
+
+TEST(CharArrayAssignment, AssignNonZeroTerminatedCharArrayOfSizeForFullCapa)
+{
+    char testString[8] = "iceoryx";
+    testString[7] = 'x'; // overwrite the 0 termination
+    string<7> testSubject(testString);
+    EXPECT_THAT(testSubject.size(), Eq(7));
+    EXPECT_THAT(testSubject.c_str(), StrEq("iceoryx"));
+}
+
 TYPED_TEST(stringTyped_test, UnsafeCharToStringConstrWithNullPtrResultsEmptyString)
 {
     using myString = typename TestFixture::stringType;

--- a/iceoryx_utils/test/moduletests/test_cxx_string.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_string.cpp
@@ -361,6 +361,14 @@ TEST(String100, UnsafeCharToStringConstrIncludingNullCharWithCountResultsInSizeC
     EXPECT_THAT(testSubject.c_str(), StrEq("ice\0ryx"));
 }
 
+TEST(CharArrayAssignment, AssignCharArrayWithStringSizeLessThanArraySize)
+{
+    char testString[20] = "iceoryx";
+    string<20> testSubject(testString);
+    EXPECT_THAT(testSubject.size(), Eq(7));
+    EXPECT_THAT(testSubject.c_str(), StrEq("iceoryx"));
+}
+
 TEST(CharArrayAssignment, AssignZeroTerminatedCharArrayOfSizeForFullCapa)
 {
     char testString[8] = "iceoryx";


### PR DESCRIPTION
closes #264 

Signed-off-by: Kraus Mathias (CC-AD/ESW1) <mathias.kraus2@de.bosch.com>