### PR TITLE
iox-#311 fixing linker error

### DIFF
--- a/iceoryx_posh/CMakeLists.txt
+++ b/iceoryx_posh/CMakeLists.txt
@@ -203,6 +203,7 @@ add_library(iceoryx_posh_roudi
     source/roudi/port_manager.cpp
     source/roudi/port_pool.cpp
     source/roudi/roudi.cpp
+    source/roudi/roudi_config.cpp
     source/roudi/roudi_lock.cpp
     source/roudi/roudi_process.cpp
     source/roudi/service_registry.cpp


### PR DESCRIPTION
Fixes #311 

Signed-off-by: Christian Eltzschig <christian.eltzschig2@de.bosch.com>