### PR TITLE
Add copyright header check

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,13 +19,13 @@ jobs:
      # Steps represent a sequence of tasks that will be executed as part of the job
      steps:
        - name: Install iceoryx dependencies
-         # Softwares installed in ubuntu-18.04 instance 
+         # Softwares installed in ubuntu-18.04 instance
          # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
          run: sudo apt-get update && sudo apt-get install -y libacl1-dev libncurses5-dev
 
        - name : Checkout
          uses: actions/checkout@v2
- 
+
        - name: Build sources
          run: |
             export NUM_CORES=`nproc`
@@ -48,13 +48,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install iceoryx dependencies
-        # Softwares installed in ubuntu-18.04 instance 
+        # Softwares installed in ubuntu-18.04 instance
         # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
         run: sudo apt-get update && sudo apt-get install -y libacl1-dev libncurses5-dev
 
       - name : Checkout
         uses: actions/checkout@v2
- 
+
       - name: Build sources
         run: |
           export NUM_CORES=`nproc`
@@ -76,7 +76,7 @@ jobs:
   macos-build-script:
     runs-on: macos-10.15
     # Softwares installed in macos-10.15 instance
-    # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md     
+    # https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -89,10 +89,10 @@ jobs:
           cd $GITHUB_WORKSPACE
           mkdir -p build
           cd build
-          git clone https://github.com/mirror/ncurses.git 
+          git clone https://github.com/mirror/ncurses.git
           cd ncurses
           git checkout v6.2
-          ./configure  --prefix=$GITHUB_WORKSPACE/build/install/prefix/ --exec-prefix=$GITHUB_WORKSPACE/build/install/prefix/ --with-termlib 
+          ./configure  --prefix=$GITHUB_WORKSPACE/build/install/prefix/ --exec-prefix=$GITHUB_WORKSPACE/build/install/prefix/ --with-termlib
           make
           make install
 

--- a/.github/workflows/build_test_cov.yml
+++ b/.github/workflows/build_test_cov.yml
@@ -1,6 +1,6 @@
 # This workflow builds & runs test cases in iceoryx
 
-name: Build, Test and get Test-Coverage 
+name: Build, Test and get Test-Coverage
 
 # Triggers the workflow on push or pull request events but only for the master branch
 on:
@@ -19,13 +19,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Install iceoryx dependencies
-        # Softwares installed in ubuntu-18.04 instance 
+        # Softwares installed in ubuntu-18.04 instance
         # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md
         run: sudo apt-get update && sudo apt-get install -y libacl1-dev libncurses5-dev git cmake build-essential lcov
 
       - name : Checkout
         uses: actions/checkout@v2
- 
+
       - name: Build, test and generate gcov report
         run: |
           export NUM_CORES=`nproc`

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
           os: [ubuntu-20.04]
-             
+
     steps:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@0.0.23
@@ -32,10 +32,10 @@ jobs:
           sudo apt-get update && sudo apt-get install -y cmake libacl1-dev libncurses5-dev pkg-config
           mkdir -p src/iceoryx
           cd $GITHUB_WORKSPACE/src/iceoryx
-        
+
       - name: Checkout
         uses: actions/checkout@v2
- 
+
       - name: Build & Test
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Check copyrights
+        run: |
+          source /opt/ros/foxy/setup.bash
+          cd $GITHUB_WORKSPACE
+          ament_copyright --exclude LICENSE CONTRIBUTING.md
+
       - name: Build & Test
         run: |
           cd $GITHUB_WORKSPACE

--- a/iceoryx_posh/cmake/iceoryx_poshConfig.cmake
+++ b/iceoryx_posh/cmake/iceoryx_poshConfig.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_posh/cmake/iceoryx_posh_deployment.cmake
+++ b/iceoryx_posh/cmake/iceoryx_posh_deployment.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_posh/cmake/iceoryxversions.cmake
+++ b/iceoryx_posh/cmake/iceoryxversions.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_posh/cmake/install_help_and_config.cmake
+++ b/iceoryx_posh/cmake/install_help_and_config.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_posh/source/capro/service_description.cpp
+++ b/iceoryx_posh/source/capro/service_description.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/capro/service_description.hpp"
 

--- a/iceoryx_posh/source/popo/building_blocks/condition_variable_signaler.cpp
+++ b/iceoryx_posh/source/popo/building_blocks/condition_variable_signaler.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/building_blocks/condition_variable_signaler.hpp"
 

--- a/iceoryx_posh/source/popo/building_blocks/condition_variable_waiter.cpp
+++ b/iceoryx_posh/source/popo/building_blocks/condition_variable_waiter.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/building_blocks/condition_variable_waiter.hpp"
 #include "iceoryx_utils/error_handling/error_handling.hpp"

--- a/iceoryx_posh/source/popo/condition.cpp
+++ b/iceoryx_posh/source/popo/condition.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/popo/condition.hpp"
 

--- a/iceoryx_posh/source/popo/guard_condition.cpp
+++ b/iceoryx_posh/source/popo/guard_condition.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/popo/guard_condition.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"

--- a/iceoryx_posh/source/popo/ports/base_port.cpp
+++ b/iceoryx_posh/source/popo/ports/base_port.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/base_port.hpp"
 

--- a/iceoryx_posh/source/popo/ports/base_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/base_port_data.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
 

--- a/iceoryx_posh/source/popo/ports/client_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_data.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/client_port_data.hpp"
 

--- a/iceoryx_posh/source/popo/ports/client_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_roudi.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/client_port_roudi.hpp"
 

--- a/iceoryx_posh/source/popo/ports/client_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/client_port_user.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/client_port_user.hpp"
 

--- a/iceoryx_posh/source/popo/ports/publisher_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_data.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/publisher_port_data.hpp"
 

--- a/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_roudi.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/publisher_port_roudi.hpp"
 

--- a/iceoryx_posh/source/popo/ports/publisher_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/publisher_port_user.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/publisher_port_user.hpp"
 

--- a/iceoryx_posh/source/popo/ports/server_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_data.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/server_port_data.hpp"
 

--- a/iceoryx_posh/source/popo/ports/server_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_roudi.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/server_port_roudi.hpp"
 

--- a/iceoryx_posh/source/popo/ports/server_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/server_port_user.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/server_port_user.hpp"
 

--- a/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp"
 

--- a/iceoryx_posh/source/popo/ports/subscriber_port_multi_producer.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_multi_producer.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_multi_producer.hpp"
 

--- a/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_roudi.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_roudi.hpp"
 

--- a/iceoryx_posh/source/popo/ports/subscriber_port_single_producer.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_single_producer.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_single_producer.hpp"
 

--- a/iceoryx_posh/source/popo/ports/subscriber_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_user.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"

--- a/iceoryx_posh/source/popo/wait_set.cpp
+++ b/iceoryx_posh/source/popo/wait_set.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_posh/popo/wait_set.hpp"
 

--- a/iceoryx_utils/cmake/IceoryxPackageHelper.cmake
+++ b/iceoryx_utils/cmake/IceoryxPackageHelper.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_utils/cmake/IceoryxPlatformDetection.cmake
+++ b/iceoryx_utils/cmake/IceoryxPlatformDetection.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_utils/cmake/iceoryx_utilsConfig.cmake
+++ b/iceoryx_utils/cmake/iceoryx_utilsConfig.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_utils/cmake/iceoryx_utils_testingConfig.cmake
+++ b/iceoryx_utils/cmake/iceoryx_utils_testingConfig.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/iceoryx_utils/platform/win/source/semaphore.cpp
+++ b/iceoryx_utils/platform/win/source/semaphore.cpp
@@ -10,7 +10,7 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License
+// limitations under the License.
 
 #include "iceoryx_utils/platform/semaphore.hpp"
 

--- a/tools/introspection/cmake/iceoryx_introspectionConfig.cmake
+++ b/tools/introspection/cmake/iceoryx_introspectionConfig.cmake
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## Details

- This PR uses [`ament_copyright`][ac] to check that all source files contain an appropriate copyright header
- Currently supported copyright headers can be found in the [`template` directory][td]
- If in the future we need a copyright header different from those provided by `ament_copyright`, we may need to create a small python package that extends the available copyright headers
- This PR also fixes certain copyright headers which had small typos which caused them to be flagged by the checker

[ac]: https://github.com/ament/ament_lint/tree/master/ament_copyright
[td]: https://github.com/ament/ament_lint/tree/master/ament_copyright/ament_copyright/template