### PR TITLE
Iox #340 simplify expected optionals

### DIFF
--- a/iceoryx_examples/icedelivery/iox_publisher_untyped_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_untyped_modern.cpp
@@ -64,7 +64,6 @@ int main()
         });
 
         std::this_thread::sleep_for(std::chrono::seconds(1));
-
     }
 
     return 0;

--- a/iceoryx_examples/icedelivery/iox_publisher_untyped_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_untyped_modern.cpp
@@ -57,7 +57,7 @@ int main()
         }
 
         // API Usage #2
-        // * Loan sample and provide logic for it immediately via a lambda
+        // * Loan sample and provide logic to use it immediately via a lambda
         untypedPublisher.loan(sizeof(Position)).and_then([&](iox::popo::Sample<void>& sample) {
             new (sample.get()) Position(ct, ct, ct);
             sample.publish();

--- a/iceoryx_examples/icedelivery/iox_subscriber_typed_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_typed_modern.cpp
@@ -50,6 +50,9 @@ void subscriberHandler(iox::popo::WaitSet& waitSet)
                         })
                         .if_empty([]{
                             std::cout << "Didn't get a value, but do something anyway." << std::endl;
+                        })
+                        .or_else([](iox::popo::ChunkReceiveError){
+                            std::cout << "Error receiving chunk." << std::endl;
                         });
             }
         }

--- a/iceoryx_examples/icedelivery/iox_subscriber_typed_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_typed_modern.cpp
@@ -44,13 +44,13 @@ void subscriberHandler(iox::popo::WaitSet& waitSet)
             auto subscriber = dynamic_cast<iox::popo::TypedSubscriber<Position>*>(condition);
             if(subscriber)
             {
-                subscriber->take().and_then([](iox::cxx::optional<iox::popo::Sample<const Position>>& maybePosition){
-                    if(maybePosition.has_value())
-                    {
-                        auto& position = maybePosition.value();
-                        std::cout << "Got value: (" << position->x << ", " << position->y << ", " << position->z << ")" << std::endl;
-                    }
-                });
+                subscriber->take()
+                        .and_then([](iox::popo::Sample<const Position>& position){
+                            std::cout << "Got value: (" << position->x << ", " << position->y << ", " << position->z << ")" << std::endl;
+                        })
+                        .if_empty([]{
+                            std::cout << "Didn't get a value, but do something anyway." << std::endl;
+                        });
             }
         }
     }

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped_modern.cpp
@@ -50,6 +50,9 @@ void subscriberHandler(iox::popo::WaitSet& waitSet)
                         })
                         .if_empty([]{
                             std::cout << "Didn't get a value, but do something anyway." << std::endl;
+                        })
+                        .or_else([](iox::popo::ChunkReceiveError){
+                            std::cout << "Error receiving chunk." << std::endl;
                         });
             }
         }

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped_modern.cpp
@@ -43,13 +43,14 @@ void subscriberHandler(iox::popo::WaitSet& waitSet)
             auto untypedSubscriber = dynamic_cast<iox::popo::UntypedSubscriber*>(condition);
             if(untypedSubscriber)
             {
-                untypedSubscriber->take().and_then([](iox::cxx::optional<iox::popo::Sample<const void>>& maybeSample){
-                    if(maybeSample.has_value())
-                    {
-                        auto position = reinterpret_cast<const Position*>(maybeSample->get());
-                        std::cout << "Got value: (" << position->x << ", " << position->y << ", " << position->z << ")" << std::endl;
-                    }
-                });
+                untypedSubscriber->take()
+                        .and_then([](iox::cxx::optional<iox::popo::Sample<const void>>& allocation){
+                                auto position = reinterpret_cast<const Position*>(allocation->get());
+                                std::cout << "Got value: (" << position->x << ", " << position->y << ", " << position->z << ")" << std::endl;
+                        })
+                        .if_empty([]{
+                            std::cout << "Didn't get a value, but do something anyway." << std::endl;
+                        });
             }
         }
     }

--- a/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
@@ -667,6 +667,9 @@ class expected<ValueType, ErrorType>
     expected& and_then(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
 
     template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    const expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const noexcept;
+
+    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept;
 
     /// @brief  if the expected does contain a success value the given callable is called and
@@ -690,6 +693,9 @@ class expected<ValueType, ErrorType>
     ///     })
     /// @endcode
     [[gnu::deprecated]] expected& on_success(const cxx::function_ref<void()>& callable) noexcept;
+
+    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    const expected& if_empty(const cxx::function_ref<void()>& callable) const noexcept;
 
     template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     expected& if_empty(const cxx::function_ref<void()>& callable) noexcept;

--- a/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
@@ -24,7 +24,6 @@ namespace iox
 {
 namespace cxx
 {
-
 /// @brief helper struct to create an expected which is signalling success more easily
 /// @param T type which the success helper class should contain
 /// @code
@@ -102,11 +101,15 @@ struct error
 template <typename... T>
 class expected;
 
-template<typename... T>
-struct is_optional : std::false_type { };
+template <typename... T>
+struct is_optional : std::false_type
+{
+};
 
-template<typename T>
-struct is_optional<iox::cxx::optional<T>> : std::true_type { };
+template <typename T>
+struct is_optional<iox::cxx::optional<T>> : std::true_type
+{
+};
 
 
 /// @brief expected implementation from the C++20 proposal with C++11. The interface
@@ -677,7 +680,7 @@ class expected<ValueType, ErrorType>
     ///     })
     /// @endcode
     ///
-    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     const expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const noexcept;
 
     ///
@@ -691,7 +694,7 @@ class expected<ValueType, ErrorType>
     ///     })
     /// @endcode
     ///
-    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept;
 
     /// @brief  if the expected does contain a success value the given callable is called and
@@ -729,7 +732,7 @@ class expected<ValueType, ErrorType>
     ///         })
     /// @endcode
     ///
-    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     const expected& if_empty(const cxx::function_ref<void()>& callable) const noexcept;
 
     ///
@@ -745,7 +748,7 @@ class expected<ValueType, ErrorType>
     ///         })
     /// @endcode
     ///
-    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     expected& if_empty(const cxx::function_ref<void()>& callable) noexcept;
 
     optional<ValueType> to_optional() const noexcept;

--- a/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
@@ -24,6 +24,7 @@ namespace iox
 {
 namespace cxx
 {
+
 /// @brief helper struct to create an expected which is signalling success more easily
 /// @param T type which the success helper class should contain
 /// @code
@@ -100,6 +101,13 @@ struct error
 
 template <typename... T>
 class expected;
+
+template<typename... T>
+struct is_optional : std::false_type { };
+
+template<typename T>
+struct is_optional<iox::cxx::optional<T>> : std::true_type { };
+
 
 /// @brief expected implementation from the C++20 proposal with C++11. The interface
 ///         is inspired by the proposal but it has changes since we are not allowed to
@@ -657,6 +665,9 @@ class expected<ValueType, ErrorType>
     /// @endcode
     [[gnu::deprecated]] expected& on_success(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
     expected& and_then(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
+
+    template<typename _ValueType = ValueType, typename std::enable_if<is_optional<_ValueType>::value, int>::type = 0>
+    expected& and_then(const cxx::function_ref<void(typename _ValueType::type&)>& callable) noexcept;
 
     /// @brief  if the expected does contain a success value the given callable is called and
     ///         a reference to the expected is given as an argument to the callable

--- a/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
@@ -666,9 +666,31 @@ class expected<ValueType, ErrorType>
     [[gnu::deprecated]] expected& on_success(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
     expected& and_then(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
 
+    ///
+    /// @brief if the expected contains a success value and its type is a non-empty optional, retrieve the value from
+    ///         the optional and provide it as the argument to the provided callable
+    /// @param[in] callable the callable to be called with the contents of the optional
+    /// @return reference to the expected
+    /// @code
+    ///     anExpectedOptional.and_then([](int& value){
+    ///         std::cout << "the optional contains the value: " << result << std::endl;
+    ///     })
+    /// @endcode
+    ///
     template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     const expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const noexcept;
 
+    ///
+    /// @brief if the expected contains a success value and its type is a non-empty optional, retrieve the value from
+    ///         the optional and provide it as the argument to the provided callable
+    /// @param[in] callable the callable to be called with the contents of the optional
+    /// @return reference to the expected
+    /// @code
+    ///     anExpectedOptional.and_then([](int& value){
+    ///         std::cout << "the optional contains the value: " << result << std::endl;
+    ///     })
+    /// @endcode
+    ///
     template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept;
 
@@ -694,9 +716,35 @@ class expected<ValueType, ErrorType>
     /// @endcode
     [[gnu::deprecated]] expected& on_success(const cxx::function_ref<void()>& callable) noexcept;
 
+    ///
+    /// @brief if the expected contains a success value and its type is an empty optional, calls the provided callable
+    /// @param[in] callable the callable to be called if the contained optional is empty
+    /// @return reference to the expected
+    /// @code
+    ///     anExpectedOptional.and_then([](SomeType& value){
+    ///             std::cout << "we got something in the optional: " << value << std::endl;
+    ///         })
+    ///         .if_empty([](){
+    ///             std::cout << "the optional was empty, but do something anyway!" << result << std::endl;
+    ///         })
+    /// @endcode
+    ///
     template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     const expected& if_empty(const cxx::function_ref<void()>& callable) const noexcept;
 
+    ///
+    /// @brief if the expected contains a success value and its type is an empty optional, calls the provided callable
+    /// @param[in] callable the callable to be called if the contained optional is empty
+    /// @return reference to the expected
+    /// @code
+    ///     anExpectedOptional.and_then([](SomeType& value){
+    ///             std::cout << "we got something in the optional: " << value << std::endl;
+    ///         })
+    ///         .if_empty([](){
+    ///             std::cout << "the optional was empty, but do something anyway!" << result << std::endl;
+    ///         })
+    /// @endcode
+    ///
     template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
     expected& if_empty(const cxx::function_ref<void()>& callable) noexcept;
 

--- a/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
@@ -703,7 +703,7 @@ class expected<ValueType, ErrorType>
     ///         std::cout << "we are successful!" << std::endl;
     ///     })
     /// @endcode
-    [[gnu::deprecated]] const expected& on_success(const cxx::function_ref<void(void)>& callable) const noexcept;
+    [[gnu::deprecated]] const expected& on_success(const cxx::function_ref<void()>& callable) const noexcept;
 
     /// @brief  if the expected does contain a success value the given callable is called and
     ///         a reference to the expected is given as an argument to the callable

--- a/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/expected.hpp
@@ -666,8 +666,8 @@ class expected<ValueType, ErrorType>
     [[gnu::deprecated]] expected& on_success(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
     expected& and_then(const cxx::function_ref<void(ValueType&)>& callable) noexcept;
 
-    template<typename _ValueType = ValueType, typename std::enable_if<is_optional<_ValueType>::value, int>::type = 0>
-    expected& and_then(const cxx::function_ref<void(typename _ValueType::type&)>& callable) noexcept;
+    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    expected& and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept;
 
     /// @brief  if the expected does contain a success value the given callable is called and
     ///         a reference to the expected is given as an argument to the callable
@@ -678,7 +678,7 @@ class expected<ValueType, ErrorType>
     ///         std::cout << "we are successful!" << std::endl;
     ///     })
     /// @endcode
-    [[gnu::deprecated]] const expected& on_success(const cxx::function_ref<void()>& callable) const noexcept;
+    [[gnu::deprecated]] const expected& on_success(const cxx::function_ref<void(void)>& callable) const noexcept;
 
     /// @brief  if the expected does contain a success value the given callable is called and
     ///         a reference to the expected is given as an argument to the callable
@@ -690,6 +690,9 @@ class expected<ValueType, ErrorType>
     ///     })
     /// @endcode
     [[gnu::deprecated]] expected& on_success(const cxx::function_ref<void()>& callable) noexcept;
+
+    template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+    expected& if_empty(const cxx::function_ref<void()>& callable) noexcept;
 
     optional<ValueType> to_optional() const noexcept;
 

--- a/iceoryx_utils/include/iceoryx_utils/cxx/optional.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/optional.hpp
@@ -58,7 +58,6 @@ template <typename T>
 class optional
 {
   public:
-
     using type = T;
 
     /// @brief Creates an optional which has no value. If you access such an

--- a/iceoryx_utils/include/iceoryx_utils/cxx/optional.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/optional.hpp
@@ -58,6 +58,9 @@ template <typename T>
 class optional
 {
   public:
+
+    using type = T;
+
     /// @brief Creates an optional which has no value. If you access such an
     ///         optional via .value() or the arrow operator the behavior is
     ///         undefined.

--- a/iceoryx_utils/include/iceoryx_utils/cxx/unique_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/cxx/unique_ptr.hpp
@@ -21,20 +21,18 @@ namespace iox
 {
 namespace cxx
 {
-
 ///
 /// @brief The unique_ptr class is a heap-less unique ptr implementation, unlike the STL.
 /// @details To avoid using the heap, deleters are not managed by the pointer itself, and instead must be provided as
 /// function references ('cxx:function_ref'). The functions must exist at least as long as the pointers that use them.
 ///
-/// Also unlike the STL implementation, the deleters are not encoded in the unique_ptr type, allowing unique_ptr instances
-/// with different deleters to be stored in the same containers.
+/// Also unlike the STL implementation, the deleters are not encoded in the unique_ptr type, allowing unique_ptr
+/// instances with different deleters to be stored in the same containers.
 ///
 template <typename T>
 class unique_ptr
 {
   public:
-
     unique_ptr() = delete;
 
     ///

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
@@ -347,12 +347,10 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(ValueType&
 }
 
 template <typename ValueType, typename ErrorType>
-template<typename _ValueType = ValueType, typename std::enable_if<is_optional<_ValueType>::value, int>::type = 0>
+template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
 inline expected<ValueType, ErrorType>&
-expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename _ValueType::type&)>& callable) noexcept
+expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept
 {
-    std::cout << "THIS IS AN OPTIONAL" << std::endl;
-
     if (!this->has_error())
     {
         auto optional = get_value();
@@ -364,6 +362,24 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename _
 
     return *this;
 }
+
+template <typename ValueType, typename ErrorType>
+template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+inline expected<ValueType, ErrorType>&
+expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& callable) noexcept
+{
+    if (!this->has_error())
+    {
+        auto optional = get_value();
+        if(!optional.has_value())
+        {
+            callable();
+        }
+    }
+
+    return *this;
+}
+
 
 template <typename ValueType, typename ErrorType>
 inline expected<ValueType, ErrorType>&

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
@@ -347,22 +347,23 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(ValueType&
 }
 
 template <typename ValueType, typename ErrorType>
-template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
 inline const expected<ValueType, ErrorType>&
-expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const noexcept
+expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const
+    noexcept
 {
     return const_cast<expected*>(this)->and_then(callable);
 }
 
 template <typename ValueType, typename ErrorType>
-template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
 inline expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept
 {
     if (!this->has_error())
     {
         auto& optional = get_value();
-        if(optional.has_value())
+        if (optional.has_value())
         {
             callable(optional.value());
         }
@@ -372,7 +373,7 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename O
 }
 
 template <typename ValueType, typename ErrorType>
-template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
 inline const expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& callable) const noexcept
 {
@@ -380,14 +381,14 @@ expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& ca
 }
 
 template <typename ValueType, typename ErrorType>
-template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
 inline expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& callable) noexcept
 {
     if (!this->has_error())
     {
         auto& optional = get_value();
-        if(!optional.has_value())
+        if (!optional.has_value())
         {
             callable();
         }

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
@@ -347,6 +347,25 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(ValueType&
 }
 
 template <typename ValueType, typename ErrorType>
+template<typename _ValueType = ValueType, typename std::enable_if<is_optional<_ValueType>::value, int>::type = 0>
+inline expected<ValueType, ErrorType>&
+expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename _ValueType::type&)>& callable) noexcept
+{
+    std::cout << "THIS IS AN OPTIONAL" << std::endl;
+
+    if (!this->has_error())
+    {
+        auto optional = get_value();
+        if(optional.has_value())
+        {
+            callable(optional.value());
+        }
+    }
+
+    return *this;
+}
+
+template <typename ValueType, typename ErrorType>
 inline expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::on_success(const cxx::function_ref<void()>& callable) noexcept
 {

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
@@ -361,7 +361,7 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename O
 {
     if (!this->has_error())
     {
-        auto optional = get_value();
+        auto& optional = get_value();
         if(optional.has_value())
         {
             callable(optional.value());
@@ -386,7 +386,7 @@ expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& ca
 {
     if (!this->has_error())
     {
-        auto optional = get_value();
+        auto& optional = get_value();
         if(!optional.has_value())
         {
             callable();

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
@@ -347,7 +347,7 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(ValueType&
 }
 
 template <typename ValueType, typename ErrorType>
-template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional, typename std::enable_if<is_optional<Optional>::value, int>::type>
 inline const expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const
     noexcept
@@ -356,7 +356,7 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename O
 }
 
 template <typename ValueType, typename ErrorType>
-template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional, typename std::enable_if<is_optional<Optional>::value, int>::type>
 inline expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept
 {
@@ -373,7 +373,7 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename O
 }
 
 template <typename ValueType, typename ErrorType>
-template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional, typename std::enable_if<is_optional<Optional>::value, int>::type>
 inline const expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& callable) const noexcept
 {
@@ -381,7 +381,7 @@ expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& ca
 }
 
 template <typename ValueType, typename ErrorType>
-template <typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+template <typename Optional, typename std::enable_if<is_optional<Optional>::value, int>::type>
 inline expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& callable) noexcept
 {

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/expected.inl
@@ -348,6 +348,14 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(ValueType&
 
 template <typename ValueType, typename ErrorType>
 template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+inline const expected<ValueType, ErrorType>&
+expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) const noexcept
+{
+    return const_cast<expected*>(this)->and_then(callable);
+}
+
+template <typename ValueType, typename ErrorType>
+template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
 inline expected<ValueType, ErrorType>&
 expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename Optional::type&)>& callable) noexcept
 {
@@ -361,6 +369,14 @@ expected<ValueType, ErrorType>::and_then(const cxx::function_ref<void(typename O
     }
 
     return *this;
+}
+
+template <typename ValueType, typename ErrorType>
+template<typename Optional = ValueType, typename std::enable_if<is_optional<Optional>::value, int>::type = 0>
+inline const expected<ValueType, ErrorType>&
+expected<ValueType, ErrorType>::if_empty(const cxx::function_ref<void(void)>& callable) const noexcept
+{
+    return const_cast<expected*>(this)->if_empty(callable);
 }
 
 template <typename ValueType, typename ErrorType>

--- a/iceoryx_utils/include/iceoryx_utils/internal/cxx/unique_ptr.inl
+++ b/iceoryx_utils/include/iceoryx_utils/internal/cxx/unique_ptr.inl
@@ -19,7 +19,6 @@ namespace iox
 {
 namespace cxx
 {
-
 template <typename T>
 unique_ptr<T>::unique_ptr(T* const ptr, function_ref<void(T*)>&& deleter) noexcept
     : m_ptr(ptr)

--- a/iceoryx_utils/test/moduletests/test_cxx_expected.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_expected.cpp
@@ -18,6 +18,14 @@
 using namespace ::testing;
 using namespace iox::cxx;
 
+class MockCallables {
+public:
+    MockCallables() = default;
+    MOCK_METHOD0(onSuccess, void());
+    MOCK_METHOD0(onEmpty, void());
+    MOCK_METHOD0(onError, void());
+};
+
 class expected_test : public Test
 {
   public:
@@ -248,3 +256,60 @@ TEST_F(expected_test, ExpectedWithErrorConvertsToNullopt)
     optional<int> value = sut.to_optional();
     ASSERT_THAT(value.has_value(), Eq(false));
 }
+
+TEST_F(expected_test, AndThenUnpacksOptionalWhenNonEmptyOptionalValue)
+{
+    auto sut = expected<iox::cxx::optional<int>, float>::create_value(123);
+    MockCallables mocks{};
+    EXPECT_CALL(mocks, onSuccess).Times(1);
+
+    sut.and_then([&mocks](int& val){
+        mocks.onSuccess();
+        ASSERT_THAT(val, Eq(123));
+    });
+}
+
+TEST_F(expected_test, AndThenNotCalledWhenEmptyOptionalValue)
+{
+    auto sut = expected<iox::cxx::optional<int>, float>::create_value(iox::cxx::nullopt);
+    MockCallables mocks{};
+    EXPECT_CALL(mocks, onSuccess).Times(0);
+
+    sut.and_then([&mocks](int&){
+        mocks.onSuccess();
+    });
+}
+
+TEST_F(expected_test, IfEmptyCalledWhenEmptyOptionalValue)
+{
+    auto sut = expected<iox::cxx::optional<int>, float>::create_value(iox::cxx::nullopt);
+    MockCallables mocks{};
+    EXPECT_CALL(mocks, onEmpty).Times(1);
+
+    sut.if_empty([&mocks](){
+        mocks.onEmpty();
+    });
+}
+
+TEST_F(expected_test, IfEmptyNotCalledWhenValueTypeIsNonEmptyOptionalValue)
+{
+    auto sut = expected<iox::cxx::optional<int>, float>::create_value(123);
+    MockCallables mocks{};
+    EXPECT_CALL(mocks, onEmpty).Times(0);
+
+    sut.if_empty([&mocks](){
+        mocks.onEmpty();
+    });
+}
+
+TEST_F(expected_test, IfEmptyNotCalledWhenErrorOccurs)
+{
+    auto sut = expected<iox::cxx::optional<int>, float>::create_error(42.42);
+    MockCallables mocks{};
+    EXPECT_CALL(mocks, onEmpty).Times(0);
+
+    sut.if_empty([&mocks](){
+        mocks.onEmpty();
+    });
+}
+

--- a/iceoryx_utils/test/moduletests/test_cxx_expected.cpp
+++ b/iceoryx_utils/test/moduletests/test_cxx_expected.cpp
@@ -18,8 +18,9 @@
 using namespace ::testing;
 using namespace iox::cxx;
 
-class MockCallables {
-public:
+class MockCallables
+{
+  public:
     MockCallables() = default;
     MOCK_METHOD0(onSuccess, void());
     MOCK_METHOD0(onEmpty, void());
@@ -263,7 +264,7 @@ TEST_F(expected_test, AndThenUnpacksOptionalWhenNonEmptyOptionalValue)
     MockCallables mocks{};
     EXPECT_CALL(mocks, onSuccess).Times(1);
 
-    sut.and_then([&mocks](int& val){
+    sut.and_then([&mocks](int& val) {
         mocks.onSuccess();
         ASSERT_THAT(val, Eq(123));
     });
@@ -275,9 +276,7 @@ TEST_F(expected_test, AndThenNotCalledWhenEmptyOptionalValue)
     MockCallables mocks{};
     EXPECT_CALL(mocks, onSuccess).Times(0);
 
-    sut.and_then([&mocks](int&){
-        mocks.onSuccess();
-    });
+    sut.and_then([&mocks](int&) { mocks.onSuccess(); });
 }
 
 TEST_F(expected_test, IfEmptyCalledWhenEmptyOptionalValue)
@@ -286,9 +285,7 @@ TEST_F(expected_test, IfEmptyCalledWhenEmptyOptionalValue)
     MockCallables mocks{};
     EXPECT_CALL(mocks, onEmpty).Times(1);
 
-    sut.if_empty([&mocks](){
-        mocks.onEmpty();
-    });
+    sut.if_empty([&mocks]() { mocks.onEmpty(); });
 }
 
 TEST_F(expected_test, IfEmptyNotCalledWhenValueTypeIsNonEmptyOptionalValue)
@@ -297,9 +294,7 @@ TEST_F(expected_test, IfEmptyNotCalledWhenValueTypeIsNonEmptyOptionalValue)
     MockCallables mocks{};
     EXPECT_CALL(mocks, onEmpty).Times(0);
 
-    sut.if_empty([&mocks](){
-        mocks.onEmpty();
-    });
+    sut.if_empty([&mocks]() { mocks.onEmpty(); });
 }
 
 TEST_F(expected_test, IfEmptyNotCalledWhenErrorOccurs)
@@ -308,8 +303,5 @@ TEST_F(expected_test, IfEmptyNotCalledWhenErrorOccurs)
     MockCallables mocks{};
     EXPECT_CALL(mocks, onEmpty).Times(0);
 
-    sut.if_empty([&mocks](){
-        mocks.onEmpty();
-    });
+    sut.if_empty([&mocks]() { mocks.onEmpty(); });
 }
-


### PR DESCRIPTION
* adds an `and_then` specialization for `cxx::expected<cxx::optional<T>>` that automatically retrieves the value from non-empty optionals
* the and_then specialization does nothing if the optional is empty
* adds `if_empty()` method to `cxx::expected<cxx::optional<T>>` types that allows users to react to retrieving an empty optional without error