### PR TITLE
iox-#328 update to ros-tooling/setup-ros@0.0.26

### DIFF
--- a/.github/workflows/colcon.yml
+++ b/.github/workflows/colcon.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Setup ROS
-        uses: ros-tooling/setup-ros@0.0.23
+        uses: ros-tooling/setup-ros@0.0.26
         with:
           required-ros-distributions: foxy
       - name: Install Iceoryx Dependencies


### PR DESCRIPTION
fix Warning in CI colcon build (github action) by updating Ros toolchain to `ros-tooling/setup-ros@0.0.26`

Warning was:
```
@github-actions github-actions / build (ubuntu-20.04)

The `set-env` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```


Signed-off-by: bishibashiB <b.eickhoff@gmx.de>