### PR TITLE
iox-#369 Destroy underlying ports when pubsub entities are destructed.

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/modern_api/base_publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/modern_api/base_publisher.inl
@@ -28,6 +28,12 @@ inline BasePublisher<T, port_t>::BasePublisher(const capro::ServiceDescription& 
 }
 
 template <typename T, typename port_t>
+inline BasePublisher<T, port_t>::~BasePublisher()
+{
+    m_port.destroy();
+}
+
+template <typename T, typename port_t>
 inline uid_t BasePublisher<T, port_t>::getUid() const noexcept
 {
     return m_port.getUniqueID();

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/modern_api/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/modern_api/base_subscriber.inl
@@ -30,6 +30,13 @@ inline BaseSubscriber<T, port_t>::BaseSubscriber(const capro::ServiceDescription
 }
 
 template <typename T, typename port_t>
+inline BaseSubscriber<T, port_t>::~BaseSubscriber()
+{
+    m_port.destroy();
+}
+
+
+template <typename T, typename port_t>
 inline uid_t BaseSubscriber<T, port_t>::getUid() const noexcept
 {
     return m_port.getUniqueID();

--- a/iceoryx_posh/include/iceoryx_posh/popo/modern_api/base_publisher.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/modern_api/base_publisher.hpp
@@ -51,7 +51,7 @@ class BasePublisher : public PublisherInterface<T>
     BasePublisher& operator=(const BasePublisher&) = delete;
     BasePublisher(BasePublisher&& rhs) = default;
     BasePublisher& operator=(BasePublisher&& rhs) = default;
-    ~BasePublisher() = default;
+    ~BasePublisher();
 
     ///
     /// @brief uid Get the UID of the publisher.

--- a/iceoryx_posh/include/iceoryx_posh/popo/modern_api/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/modern_api/base_subscriber.hpp
@@ -36,7 +36,7 @@ class BaseSubscriber : public Condition
     BaseSubscriber& operator=(const BaseSubscriber&) = delete;
     BaseSubscriber(BaseSubscriber&& rhs) = delete;
     BaseSubscriber& operator=(BaseSubscriber&& rhs) = delete;
-    ~BaseSubscriber() = default;
+    ~BaseSubscriber();
 
     ///
     /// @brief uid Get the unique ID of the subscriber.

--- a/iceoryx_posh/test/mocks/publisher_mock.hpp
+++ b/iceoryx_posh/test/mocks/publisher_mock.hpp
@@ -42,6 +42,7 @@ class MockPublisherPortUser
     MOCK_METHOD0(stopOffer, void());
     MOCK_CONST_METHOD0(isOffered, bool());
     MOCK_CONST_METHOD0(hasSubscribers, bool());
+    MOCK_METHOD0(destroy, void());
 };
 
 template <typename T>

--- a/iceoryx_posh/test/mocks/subscriber_mock.hpp
+++ b/iceoryx_posh/test/mocks/subscriber_mock.hpp
@@ -49,6 +49,7 @@ class MockSubscriberPortUser
     MOCK_METHOD1(setConditionVariable, bool(iox::popo::ConditionVariableData*));
     MOCK_METHOD0(unsetConditionVariable, bool());
     MOCK_METHOD0(isConditionVariableSet, bool());
+    MOCK_METHOD0(destroy, bool());
 };
 
 template <typename T>

--- a/iceoryx_posh/test/moduletests/test_popo_base_publisher.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_publisher.cpp
@@ -247,3 +247,9 @@ TEST_F(BasePublisherTest, GetServiceDescriptionCallForwardedToUnderlyingPublishe
     // ===== Verify ===== //
     // ===== Cleanup ===== //
 }
+
+TEST_F(BasePublisherTest, DestroysUnderlyingPortOnDestruction)
+{
+    EXPECT_CALL(sut.getMockedPort(), destroy).Times(1);
+}
+

--- a/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
@@ -281,3 +281,12 @@ TEST_F(BaseSubscriberTest, HasMissedSamplesCallForwardedToUnderlyingSubscriberPo
     // ===== Verify ===== //
     // ===== Cleanup ===== //
 }
+
+TEST_F(BaseSubscriberTest, DestroysUnderlyingPortOnDestruction)
+{
+    // ===== Setup ===== //
+    EXPECT_CALL(sut.getMockedPort(), destroy).Times(1);
+    // ===== Test ===== //
+    // ===== Verify ===== //
+    // ===== Cleanup ===== //
+}


### PR DESCRIPTION
Addressing the port memory leak - ports will now be automatically destroyed when publishers or subscribers are destructed.
We can discuss further in #369 if we need to do anything else to resolve it.

Signed-off-by: Ithier Jeff (CC-AD/EYF1) <jeff.ithier@de.bosch.com>