### PR TITLE
iox-#260 remove std::string from PosixAccessRights, AccessControl and SegmentConfig

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/mepoo/segment_config.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/mepoo/segment_config.hpp
@@ -19,8 +19,7 @@
 
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_utils/cxx/vector.hpp"
-
-#include <string>
+#include "iceoryx_utils/posix_wrapper/posix_access_rights.hpp"
 
 namespace iox
 {
@@ -30,8 +29,8 @@ struct SegmentConfig
 {
     struct SegmentEntry
     {
-        SegmentEntry(const std::string& readerGroup,
-                     const std::string& writerGroup,
+        SegmentEntry(const posix::PosixGroup::string_t& readerGroup,
+                     const posix::PosixGroup::string_t& writerGroup,
                      const MePooConfig& memPoolConfig,
                      iox::mepoo::MemoryInfo memoryInfo = iox::mepoo::MemoryInfo())
             : m_readerGroup(readerGroup)
@@ -42,8 +41,8 @@ struct SegmentConfig
         {
         }
 
-        std::string m_readerGroup;
-        std::string m_writerGroup;
+        posix::PosixGroup::string_t m_readerGroup;
+        posix::PosixGroup::string_t m_writerGroup;
         MePooConfig m_mempoolConfig;
         iox::mepoo::MemoryInfo m_memoryInfo;
     };

--- a/iceoryx_posh/source/roudi/roudi_config_toml_file_provider.cpp
+++ b/iceoryx_posh/source/roudi/roudi_config_toml_file_provider.cpp
@@ -15,6 +15,7 @@
 #include "iceoryx_posh/roudi/roudi_config_toml_file_provider.hpp"
 #include "iceoryx_posh/internal/log/posh_logging.hpp"
 #include "iceoryx_posh/roudi/roudi_cmd_line_parser.hpp"
+#include "iceoryx_utils/cxx/string.hpp"
 #include "iceoryx_utils/cxx/vector.hpp"
 #include "iceoryx_utils/internal/file_reader/file_reader.hpp"
 #include "iceoryx_utils/platform/getopt.hpp"
@@ -126,7 +127,10 @@ iox::cxx::expected<iox::RouDiConfig_t, iox::roudi::RouDiConfigFileParseError> To
             }
             mempoolConfig.addMemPool({*chunkSize, *chunkCount});
         }
-        parsedConfig.m_sharedMemorySegments.push_back({reader, writer, mempoolConfig});
+        parsedConfig.m_sharedMemorySegments.push_back(
+            {iox::posix::PosixGroup::string_t(iox::cxx::TruncateToCapacity, reader),
+             iox::posix::PosixGroup::string_t(iox::cxx::TruncateToCapacity, writer),
+             mempoolConfig});
     }
 
     return iox::cxx::success<iox::RouDiConfig_t>(parsedConfig);

--- a/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/access_control.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/posix_wrapper/access_control.hpp
@@ -15,6 +15,7 @@
 #define IOX_UTILS_POSIX_WRAPPER_ACCESS_CONTROL_HPP
 
 #include "iceoryx_utils/cxx/optional.hpp"
+#include "iceoryx_utils/cxx/string.hpp"
 #include "iceoryx_utils/cxx/vector.hpp"
 #include "iceoryx_utils/platform/acl.hpp"
 
@@ -38,7 +39,7 @@ namespace posix
 class AccessController
 {
   public:
-    using string_t = std::string;
+    using string_t = cxx::string<100>;
 
     /// @brief maximum number of permission entries the AccessController can store
     static constexpr int32_t MaxNumOfPermissions = 20;

--- a/iceoryx_utils/include/iceoryx_utils/posix_wrapper/posix_access_rights.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/posix_wrapper/posix_access_rights.hpp
@@ -15,6 +15,7 @@
 #define IOX_UTILS_POSIX_WRAPPER_POSIX_ACCESS_RIGHTS_HPP
 
 #include "iceoryx_utils/cxx/optional.hpp"
+#include "iceoryx_utils/cxx/string.hpp"
 #include "iceoryx_utils/cxx/vector.hpp"
 #include "iceoryx_utils/platform/types.hpp"
 
@@ -37,7 +38,7 @@ struct PosixRights
 class PosixGroup
 {
   public:
-    using string_t = std::string;
+    using string_t = cxx::string<100>;
     PosixGroup(gid_t f_id);
     PosixGroup(string_t f_name);
 
@@ -62,7 +63,7 @@ class PosixUser
 {
   public:
     using groupVector_t = cxx::vector<PosixGroup, MaxNumberOfGroups>;
-    using string_t = std::string;
+    using string_t = cxx::string<100>;
 
     PosixUser(uid_t f_id);
     PosixUser(const string_t& f_name);

--- a/iceoryx_utils/source/posix_wrapper/posix_access_rights.cpp
+++ b/iceoryx_utils/source/posix_wrapper/posix_access_rights.cpp
@@ -89,7 +89,7 @@ cxx::optional<PosixGroup::string_t> PosixGroup::getGroupName(gid_t f_id)
         return cxx::nullopt_t();
     }
 
-    return cxx::make_optional<string_t>(getgrgidCall.getReturnValue()->gr_name);
+    return cxx::make_optional<string_t>(string_t(iox::cxx::TruncateToCapacity, getgrgidCall.getReturnValue()->gr_name));
 }
 
 PosixGroup::string_t PosixGroup::getName() const
@@ -138,7 +138,7 @@ cxx::optional<PosixUser::string_t> PosixUser::getUserName(uid_t f_id)
         std::cerr << "Error: Could not find user with id'" << f_id << "'." << std::endl;
         return cxx::nullopt_t();
     }
-    return cxx::make_optional<string_t>(getpwnamCall.getReturnValue()->pw_name);
+    return cxx::make_optional<string_t>(string_t(iox::cxx::TruncateToCapacity, getpwnamCall.getReturnValue()->pw_name));
 }
 
 PosixUser::groupVector_t PosixUser::getGroups() const

--- a/iceoryx_utils/test/moduletests/test_access_control.cpp
+++ b/iceoryx_utils/test/moduletests/test_access_control.cpp
@@ -98,7 +98,7 @@ TEST_F(AccessController_test, writeSpecialUserPermissions)
     // no name specified
     EXPECT_FALSE(entryAdded);
 
-    std::string currentUserName(getpwuid(geteuid())->pw_name);
+    AccessController::string_t currentUserName(iox::cxx::TruncateToCapacity, getpwuid(geteuid())->pw_name);
 
     entryAdded = m_accessController.addPermissionEntry(
         AccessController::Category::SPECIFIC_USER, AccessController::Permission::READWRITE, currentUserName);
@@ -136,7 +136,7 @@ TEST_F(AccessController_test, writeSpecialGroupPermissions)
     // no name specified
     EXPECT_FALSE(entryAdded);
 
-    std::string groupName = "root";
+    AccessController::string_t groupName = "root";
 
     entryAdded = m_accessController.addPermissionEntry(
         AccessController::Category::SPECIFIC_GROUP, AccessController::Permission::READWRITE, groupName);
@@ -205,7 +205,7 @@ TEST_F(AccessController_test, writeSpecialPermissionsWithID)
 
 TEST_F(AccessController_test, addNameInWrongPlace)
 {
-    std::string currentUserName(getpwuid(geteuid())->pw_name);
+    AccessController::string_t currentUserName(iox::cxx::TruncateToCapacity, getpwuid(geteuid())->pw_name);
 
     // this is not allowed as the default user should not be named explicitly
     m_accessController.addPermissionEntry(
@@ -220,7 +220,7 @@ TEST_F(AccessController_test, addNameInWrongPlace)
 
 TEST_F(AccessController_test, addManyPermissions)
 {
-    std::string groupName = "root";
+    AccessController::string_t groupName = "root";
 
     bool entryAdded;
     for (int i = 0; i < AccessController::MaxNumOfPermissions; ++i)


### PR DESCRIPTION
First part on the journey to remove std::string from the utils

partly closes #260 

Signed-off-by: Mathias Kraus <mathias.kraus@apex.ai>