### PR TITLE
Iox #260 remove std string from posh part 1

### DIFF
--- a/iceoryx_binding_c/include/iceoryx_binding_c/runnable.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/runnable.h
@@ -33,7 +33,8 @@ void iox_runnable_destroy(iox_runnable_t const self);
 /// @param[in] name pointer to a memory location where the name can be written to
 /// @param[in] nameCapacity size of the memory location where the name is written to
 /// @return the actual length of the runnable name, if the return value is greater
-///         then nameCapacity the name is truncated
+///         then nameCapacity the name is truncated.
+///         If name is a nullptr, 0 will be returned.
 uint64_t iox_runnable_get_name(iox_runnable_t const self, char* const name, const uint64_t nameCapacity);
 
 /// @brief acquires the name of the process in which the runnable is stored
@@ -41,7 +42,8 @@ uint64_t iox_runnable_get_name(iox_runnable_t const self, char* const name, cons
 /// @param[in] name pointer to a memory location where the name can be written to
 /// @param[in] nameCapacity size of the memory location where the name is written to
 /// @return the actual length of the process name, if the return value is greater
-///         then nameCapacity the name is truncated
+///         then nameCapacity the name is truncated.
+///         If name is a nullptr, 0 will be returned.
 uint64_t iox_runnable_get_process_name(iox_runnable_t const self, char* const name, const uint64_t nameCapacity);
 
 #endif

--- a/iceoryx_binding_c/include/iceoryx_binding_c/runtime.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/runtime.h
@@ -27,6 +27,7 @@ void iox_runtime_register(const char* const name);
 /// @return The length of the instance-name. If the instance-name is longer then nameLength a
 ///         number greater nameLength is returned and the instance-name, truncated
 ///         to nameLength, is written into the memory location of name.
+///         If name is a nullptr, 0 will be returned.
 uint64_t iox_runtime_get_instance_name(char* const name, const uint64_t nameLength);
 
 #endif

--- a/iceoryx_binding_c/source/c_runnable.cpp
+++ b/iceoryx_binding_c/source/c_runnable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,15 +56,28 @@ void iox_runnable_destroy(iox_runnable_t const self)
 
 uint64_t iox_runnable_get_name(iox_runnable_t const self, char* const name, const uint64_t nameCapacity)
 {
+    if (name == nullptr)
+    {
+        return 0;
+    }
+
     auto nameAsString = RunnableBindingExtension(self).getRunnableName();
     strncpy(name, nameAsString.c_str(), nameCapacity);
+    name[nameCapacity - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
+
     return nameAsString.size();
 }
 
 uint64_t iox_runnable_get_process_name(iox_runnable_t const self, char* const name, const uint64_t nameCapacity)
 {
+    if (name == nullptr)
+    {
+        return 0;
+    }
+
     auto nameAsString = RunnableBindingExtension(self).getProcessName();
     strncpy(name, nameAsString.c_str(), nameCapacity);
+    name[nameCapacity - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
+
     return nameAsString.size();
 }
-

--- a/iceoryx_binding_c/source/c_runnable.cpp
+++ b/iceoryx_binding_c/source/c_runnable.cpp
@@ -58,12 +58,12 @@ uint64_t iox_runnable_get_name(iox_runnable_t const self, char* const name, cons
 {
     if (name == nullptr)
     {
-        return 0;
+        return 0U;
     }
 
     auto nameAsString = RunnableBindingExtension(self).getRunnableName();
     strncpy(name, nameAsString.c_str(), nameCapacity);
-    name[nameCapacity - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
+    name[nameCapacity - 1U] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
 
     return nameAsString.size();
 }
@@ -72,12 +72,12 @@ uint64_t iox_runnable_get_process_name(iox_runnable_t const self, char* const na
 {
     if (name == nullptr)
     {
-        return 0;
+        return 0U;
     }
 
     auto nameAsString = RunnableBindingExtension(self).getProcessName();
     strncpy(name, nameAsString.c_str(), nameCapacity);
-    name[nameCapacity - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
+    name[nameCapacity - 1U] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
 
     return nameAsString.size();
 }

--- a/iceoryx_binding_c/source/c_runtime.cpp
+++ b/iceoryx_binding_c/source/c_runtime.cpp
@@ -45,9 +45,9 @@ uint64_t iox_runtime_get_instance_name(char* const name, const uint64_t nameLeng
     }
 
     auto instanceName = PoshRuntime::getInstance().getInstanceName();
-    uint64_t instanceNameSize = instanceName.size();
-    std::strncpy(name, instanceName.c_str(), std::min(nameLength, instanceNameSize));
+    std::strncpy(name, instanceName.c_str(), nameLength);
     name[nameLength - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
 
-    return instanceNameSize;
+    return instanceName.size();
+    ;
 }

--- a/iceoryx_binding_c/source/c_runtime.cpp
+++ b/iceoryx_binding_c/source/c_runtime.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,13 +23,31 @@ extern "C" {
 
 void iox_runtime_register(const char* const name)
 {
-    PoshRuntime::getInstance(name);
+    if (name == nullptr)
+    {
+        LogError() << "Application name is a nullptr!";
+        std::terminate();
+    }
+    else if (strnlen(name, iox::MAX_PROCESS_NAME_LENGTH + 1) > MAX_PROCESS_NAME_LENGTH)
+    {
+        LogError() << "Application name has more than 100 characters!";
+        std::terminate();
+    }
+
+    PoshRuntime::getInstance(ProcessName_t(iox::cxx::TruncateToCapacity, name));
 }
 
 uint64_t iox_runtime_get_instance_name(char* const name, const uint64_t nameLength)
 {
+    if (name == nullptr)
+    {
+        return 0;
+    }
+
     auto instanceName = PoshRuntime::getInstance().getInstanceName();
     uint64_t instanceNameSize = instanceName.size();
-    strncpy(name, instanceName.c_str(), std::min(nameLength, instanceNameSize));
+    std::strncpy(name, instanceName.c_str(), std::min(nameLength, instanceNameSize));
+    name[nameLength - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
+
     return instanceNameSize;
 }

--- a/iceoryx_binding_c/source/c_runtime.cpp
+++ b/iceoryx_binding_c/source/c_runtime.cpp
@@ -41,13 +41,12 @@ uint64_t iox_runtime_get_instance_name(char* const name, const uint64_t nameLeng
 {
     if (name == nullptr)
     {
-        return 0;
+        return 0U;
     }
 
     auto instanceName = PoshRuntime::getInstance().getInstanceName();
     std::strncpy(name, instanceName.c_str(), nameLength);
-    name[nameLength - 1] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
+    name[nameLength - 1U] = '\0'; // strncpy doesn't add a null-termination if destination is smaller than source
 
     return instanceName.size();
-    ;
 }

--- a/iceoryx_binding_c/test/integrationtests/test_runnable.cpp
+++ b/iceoryx_binding_c/test/integrationtests/test_runnable.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -50,9 +50,55 @@ TEST_F(iox_runnable_test, createdRunnableHasCorrectRunnableName)
     EXPECT_EQ(std::string(name), m_runnableName);
 }
 
+TEST_F(iox_runnable_test, getRunnableNameBufferIsNullptr)
+{
+    auto nameLength = iox_runnable_get_name(m_sut, nullptr, 100);
+
+    ASSERT_THAT(nameLength, Eq(0U));
+}
+
+TEST_F(iox_runnable_test, getRunnableNameBufferIsLessThanRunnableNameLength)
+{
+    constexpr uint64_t RUNNABLE_NAME_BUFFER_LENGTH{10};
+    char truncatedRunnableName[RUNNABLE_NAME_BUFFER_LENGTH];
+    for (auto& c : truncatedRunnableName)
+    {
+        c = '#';
+    }
+    auto nameLength = iox_runnable_get_name(m_sut, truncatedRunnableName, RUNNABLE_NAME_BUFFER_LENGTH);
+
+    std::string expectedRunnableName = "hypnotoad";
+
+    ASSERT_THAT(nameLength, Eq(m_runnableName.size()));
+    EXPECT_THAT(truncatedRunnableName, StrEq(expectedRunnableName));
+}
+
 TEST_F(iox_runnable_test, createdRunnableHasCorrectProcessName)
 {
     char name[100];
     ASSERT_EQ(iox_runnable_get_process_name(m_sut, name, 100), m_processName.size());
     EXPECT_EQ(std::string(name), m_processName);
+}
+
+TEST_F(iox_runnable_test, getRunnableProcessNameBufferIsNullptr)
+{
+    auto nameLength = iox_runnable_get_process_name(m_sut, nullptr, 100);
+
+    ASSERT_THAT(nameLength, Eq(0U));
+}
+
+TEST_F(iox_runnable_test, getRunnableProcessNameBufferIsLessThanRunnableProcessNameLength)
+{
+    constexpr uint64_t PROCESS_NAME_BUFFER_LENGTH{10};
+    char truncatedProcessName[PROCESS_NAME_BUFFER_LENGTH];
+    for (auto& c : truncatedProcessName)
+    {
+        c = '#';
+    }
+    auto nameLength = iox_runnable_get_process_name(m_sut, truncatedProcessName, PROCESS_NAME_BUFFER_LENGTH);
+
+    std::string expectedProcessName = "/stoepsel";
+
+    ASSERT_THAT(nameLength, Eq(m_processName.size()));
+    EXPECT_THAT(truncatedProcessName, StrEq(expectedProcessName));
 }

--- a/iceoryx_binding_c/test/integrationtests/test_runtime.cpp
+++ b/iceoryx_binding_c/test/integrationtests/test_runtime.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2020 by Apex.AI Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+extern "C" {
+#include "iceoryx_binding_c/runtime.h"
+}
+
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
+#include "testutils/roudi_gtest.hpp"
+
+using namespace iox;
+using namespace iox::runtime;
+
+class BindingC_Runtime_test : public RouDi_GTest
+{
+  public:
+    void SetUp()
+    {
+    }
+
+    void TearDown()
+    {
+    }
+};
+
+TEST_F(BindingC_Runtime_test, SuccessfulRegistration)
+{
+    constexpr char EXPECTED_APP_NAME[iox::MAX_PROCESS_NAME_LENGTH + 1] = "/chucky";
+    iox_runtime_register(EXPECTED_APP_NAME);
+
+    char actualAppName[iox::MAX_PROCESS_NAME_LENGTH + 1];
+    auto nameLength = iox_runtime_get_instance_name(actualAppName, iox::MAX_PROCESS_NAME_LENGTH + 1);
+
+    ASSERT_THAT(nameLength, Eq(strnlen(EXPECTED_APP_NAME, iox::MAX_PROCESS_NAME_LENGTH + 1)));
+    EXPECT_THAT(actualAppName, StrEq(EXPECTED_APP_NAME));
+}
+
+TEST_F(BindingC_Runtime_test, AppNameLengthIsMax)
+{
+    std::string maxName(iox::MAX_PROCESS_NAME_LENGTH, 's');
+    maxName.front() = '/';
+
+    iox_runtime_register(maxName.c_str());
+
+    char actualAppName[iox::MAX_PROCESS_NAME_LENGTH + 1];
+    auto nameLength = iox_runtime_get_instance_name(actualAppName, iox::MAX_PROCESS_NAME_LENGTH + 1);
+
+    ASSERT_THAT(nameLength, Eq(iox::MAX_PROCESS_NAME_LENGTH));
+}
+
+TEST_F(BindingC_Runtime_test, AppNameLengthIsOutOfLimit)
+{
+    std::string tooLongName(iox::MAX_PROCESS_NAME_LENGTH + 1, 's');
+    tooLongName.insert(0, 1, '/');
+
+    EXPECT_DEATH({ iox_runtime_register(tooLongName.c_str()); }, "Application name has more than 100 characters!");
+}
+
+TEST_F(BindingC_Runtime_test, AppNameIsNullptr)
+{
+    EXPECT_DEATH({ iox_runtime_register(nullptr); }, "Application name is a nullptr!");
+}
+
+TEST_F(BindingC_Runtime_test, GetInstanceNameIsNullptr)
+{
+    constexpr char EXPECTED_APP_NAME[iox::MAX_PROCESS_NAME_LENGTH + 1] = "/chucky";
+    iox_runtime_register(EXPECTED_APP_NAME);
+
+    char actualAppName[iox::MAX_PROCESS_NAME_LENGTH + 1];
+    auto nameLength = iox_runtime_get_instance_name(nullptr, iox::MAX_PROCESS_NAME_LENGTH + 1);
+
+    ASSERT_THAT(nameLength, Eq(0U));
+}
+
+TEST_F(BindingC_Runtime_test, GetInstanceNameLengthIsLessThanAppNameLength)
+{
+    constexpr char ACTUAL_APP_NAME[iox::MAX_PROCESS_NAME_LENGTH + 1] = "/chucky";
+    constexpr char EXPECTED_APP_NAME[iox::MAX_PROCESS_NAME_LENGTH + 1] = "/chuck";
+    iox_runtime_register(ACTUAL_APP_NAME);
+
+    constexpr uint64_t TRUNCATED_APP_NAME_LENGTH{6};
+    char truncatedAppName[TRUNCATED_APP_NAME_LENGTH + 1];
+    for(auto& c: truncatedAppName) {
+        c = '#';
+    }
+    auto nameLength = iox_runtime_get_instance_name(truncatedAppName, TRUNCATED_APP_NAME_LENGTH + 1);
+
+    ASSERT_THAT(nameLength, Eq(strnlen(ACTUAL_APP_NAME, iox::MAX_PROCESS_NAME_LENGTH + 1)));
+    EXPECT_THAT(truncatedAppName, StrEq(EXPECTED_APP_NAME));
+}

--- a/iceoryx_binding_c/test/integrationtests/test_runtime.cpp
+++ b/iceoryx_binding_c/test/integrationtests/test_runtime.cpp
@@ -89,12 +89,13 @@ TEST_F(BindingC_Runtime_test, GetInstanceNameLengthIsLessThanAppNameLength)
     constexpr char EXPECTED_APP_NAME[iox::MAX_PROCESS_NAME_LENGTH + 1] = "/chuck";
     iox_runtime_register(ACTUAL_APP_NAME);
 
-    constexpr uint64_t TRUNCATED_APP_NAME_LENGTH{6};
-    char truncatedAppName[TRUNCATED_APP_NAME_LENGTH + 1];
-    for(auto& c: truncatedAppName) {
+    constexpr uint64_t APP_NAME_BUFFER_LENGTH{7};
+    char truncatedAppName[APP_NAME_BUFFER_LENGTH];
+    for (auto& c : truncatedAppName)
+    {
         c = '#';
     }
-    auto nameLength = iox_runtime_get_instance_name(truncatedAppName, TRUNCATED_APP_NAME_LENGTH + 1);
+    auto nameLength = iox_runtime_get_instance_name(truncatedAppName, APP_NAME_BUFFER_LENGTH);
 
     ASSERT_THAT(nameLength, Eq(strnlen(ACTUAL_APP_NAME, iox::MAX_PROCESS_NAME_LENGTH + 1)));
     EXPECT_THAT(truncatedAppName, StrEq(EXPECTED_APP_NAME));

--- a/iceoryx_posh/include/iceoryx_posh/capro/service_description.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/capro/service_description.hpp
@@ -135,13 +135,7 @@ class ServiceDescription
     ServiceDescription& operator=(ServiceDescription&&) = default;
 
     /// @brief serialization of the capro description.
-    /// @todo operator Serialization() replaces getServiceString()
     operator cxx::Serialization() const;
-
-    /// @brief Generate a servicestring filled with the member variables for
-    /// service communication
-    /// @return stringstream filled with member vars ()
-    std::string getServiceString() const noexcept;
 
     /// @brief Returns true if it contains a service description which does not have
     ///             events, otherwise it returns false

--- a/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/iceoryx_posh_types.hpp
@@ -185,7 +185,7 @@ struct DefaultChunkQueueConfig
 
 // alias for cxx::string
 using ConfigFilePathString_t = cxx::string<1024>;
-using ProcessName_t = cxx::string<100>;
+using ProcessName_t = cxx::string<MAX_PROCESS_NAME_LENGTH>;
 using RunnableName_t = cxx::string<100>;
 
 namespace runtime

--- a/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/mepoo/segment_manager.hpp
@@ -19,6 +19,7 @@
 #include "iceoryx_posh/internal/mepoo/memory_manager.hpp"
 #include "iceoryx_posh/internal/mepoo/mepoo_segment.hpp"
 #include "iceoryx_posh/mepoo/segment_config.hpp"
+#include "iceoryx_utils/cxx/string.hpp"
 #include "iceoryx_utils/cxx/vector.hpp"
 #include "iceoryx_utils/internal/posix_wrapper/shared_memory_object/allocator.hpp"
 #include "iceoryx_utils/posix_wrapper/posix_access_rights.hpp"
@@ -49,7 +50,9 @@ class SegmentManager
     struct SegmentMapping
     {
       public:
-        SegmentMapping(const std::string& sharedMemoryName,
+        using string_t = cxx::string<128>;
+
+        SegmentMapping(const string_t& sharedMemoryName,
                        void* startAddress,
                        uint64_t size,
                        bool isWritable,
@@ -65,7 +68,7 @@ class SegmentManager
         {
         }
 
-        std::string m_sharedMemoryName{""};
+        string_t m_sharedMemoryName{""};
         void* m_startAddress{nullptr};
         uint64_t m_size{0};
         bool m_isWritable{false};

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/roudi_environment.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/roudi_environment.hpp
@@ -15,6 +15,7 @@
 #define IOX_POSH_ROUDI_ENVIRONMENT_ROUDI_ENVIRONMENT_HPP
 
 #include "iceoryx_posh/iceoryx_posh_config.hpp"
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/internal/roudi/roudi.hpp"
 #include "iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp"
 #include "iceoryx_posh/roudi/iceoryx_roudi_components.hpp"
@@ -48,7 +49,7 @@ class RouDiEnvironment
     void SetInterOpWaitingTime(const std::chrono::milliseconds& v);
     void InterOpWait();
 
-    void CleanupAppResources(const std::string& name);
+    void CleanupAppResources(const ProcessName_t& name);
 
   protected:
     /// @note this is due to ambiguity of the cTor with the default parameter

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
@@ -14,6 +14,8 @@
 #ifndef IOX_POSH_ROUDI_ENVIRONMENT_RUNTIME_TEST_INTERFACE_HPP
 #define IOX_POSH_ROUDI_ENVIRONMENT_RUNTIME_TEST_INTERFACE_HPP
 
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
+
 #include <atomic>
 #include <map>
 #include <mutex>
@@ -39,10 +41,10 @@ class RuntimeTestInterface
 
     static std::mutex s_runtimeAccessMutex;
 
-    static std::map<std::string, runtime::PoshRuntime*> s_runtimes;
+    static std::map<ProcessName_t, runtime::PoshRuntime*> s_runtimes;
 
     /// This is a replacement for the PoshRuntime::GetInstance factory method
-    /// @param [in] f_name ist the name of the runtime
+    /// @param [in] name ist the name of the runtime
     /// @return a reference to a PoshRuntime
     /// @note The runtime is stored in a vector and a thread local storage.
     ///
@@ -60,7 +62,7 @@ class RuntimeTestInterface
     ///         - FindService, OfferService and StopOfferService
     ///       This means that iox::runtime::PoshRuntimeImp::GetInstance(...) must be called before the above classes
     ///       are created or functions are called, to make the correct runtime active.
-    static runtime::PoshRuntime& runtimeFactoryGetInstance(const std::string& f_name);
+    static runtime::PoshRuntime& runtimeFactoryGetInstance(const ProcessName_t& name);
 
   public:
     RuntimeTestInterface(RuntimeTestInterface&& rhs);
@@ -75,7 +77,7 @@ class RuntimeTestInterface
 
     void cleanupRuntimes();
 
-    void eraseRuntime(const std::string& f_name);
+    void eraseRuntime(const ProcessName_t& name);
 };
 
 } // namespace roudi

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include "iceoryx_posh/internal/runtime/runnable_property.hpp"
 #include "iceoryx_posh/internal/runtime/shared_memory_user.hpp"
 #include "iceoryx_posh/runtime/port_config_info.hpp"
+#include "iceoryx_utils/cxx/string.hpp"
 
 #include <atomic>
 #include <map>
@@ -46,20 +47,17 @@ namespace runtime
 class Runnable;
 class RunnableData;
 
-constexpr char DEFAULT_RUNTIME_INSTANCE_NAME[] = "dummy";
-
-
 /// @brief The runtime that is needed for each application to communicate with the RouDi daemon
 class PoshRuntime
 {
   public:
     /// @brief creates the runtime or return the already existing one -> Singleton
     /// @param[in] name name that is used for registering the process with the RouDi daemon
-    static PoshRuntime& getInstance(const std::string& name = DEFAULT_RUNTIME_INSTANCE_NAME) noexcept;
+    static PoshRuntime& getInstance(const ProcessName_t& name = defaultRuntimeInstanceName()) noexcept;
 
     /// @brief get the name that was used to register with RouDi
     /// @return name of the reistered application
-    std::string getInstanceName() const noexcept;
+    ProcessName_t getInstanceName() const noexcept;
 
     /// @brief find all services that match the provided service description
     /// @param[in] serviceDescription service to search for
@@ -169,10 +167,12 @@ class PoshRuntime
 
   protected:
     // Protected constructor for IPC setup
-    PoshRuntime(const std::string& name, const bool doMapSharedMemoryIntoThread = true) noexcept;
+    PoshRuntime(const ProcessName_t& name, const bool doMapSharedMemoryIntoThread = true) noexcept;
 
-    static std::function<PoshRuntime&(const std::string& name)> s_runtimeFactory; // = DefaultRuntimeFactory;
-    static PoshRuntime& defaultRuntimeFactory(const std::string& name) noexcept;
+    static std::function<PoshRuntime&(const ProcessName_t& name)> s_runtimeFactory; // = DefaultRuntimeFactory;
+    static PoshRuntime& defaultRuntimeFactory(const ProcessName_t& name) noexcept;
+
+    static ProcessName_t& defaultRuntimeInstanceName() noexcept;
 
   private:
     /// @deprecated #25
@@ -193,9 +193,9 @@ class PoshRuntime
 
     /// @brief checks the given application name for certain constraints like length(100 chars) or leading slash
     /// @todo replace length check with fixedstring when its integrated
-    const std::string& verifyInstanceName(const std::string& name) noexcept;
+    const ProcessName_t& verifyInstanceName(const ProcessName_t& name) noexcept;
 
-    const std::string m_appName;
+    const ProcessName_t m_appName;
     mutable std::mutex m_appMqRequestMutex;
 
     // Message queue interface for POSIX IPC from RouDi

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime_single_process.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime_single_process.hpp
@@ -14,9 +14,8 @@
 #ifndef IOX_POSH_RUNTIME_POSH_RUNTIME_SINGLE_PROCESS_HPP
 #define IOX_POSH_RUNTIME_POSH_RUNTIME_SINGLE_PROCESS_HPP
 
+#include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
-
-#include <string>
 
 namespace iox
 {
@@ -25,7 +24,7 @@ namespace runtime
 class PoshRuntimeSingleProcess : public PoshRuntime
 {
   public:
-    PoshRuntimeSingleProcess(const std::string& name) noexcept;
+    PoshRuntimeSingleProcess(const ProcessName_t& name) noexcept;
     ~PoshRuntimeSingleProcess();
 };
 } // namespace runtime

--- a/iceoryx_posh/source/capro/service_description.cpp
+++ b/iceoryx_posh/source/capro/service_description.cpp
@@ -228,15 +228,6 @@ ServiceDescription::operator cxx::Serialization() const
                                       interface);
 }
 
-std::string ServiceDescription::getServiceString() const noexcept
-{
-    std::stringstream l_strStream;
-    l_strStream << "Service_" << std::uppercase << std::setfill('0') << std::setw(4) << std::hex << m_serviceID << "_"
-                << std::uppercase << std::setfill('0') << std::setw(4) << std::hex << m_eventID << "_" << std::uppercase
-                << std::setfill('0') << std::setw(4) << std::hex << m_instanceID;
-    return l_strStream.str();
-}
-
 uint16_t ServiceDescription::getInstanceID() const noexcept
 {
     return m_instanceID;

--- a/iceoryx_posh/source/roudi_environment/roudi_environment.cpp
+++ b/iceoryx_posh/source/roudi_environment/roudi_environment.cpp
@@ -61,7 +61,7 @@ void RouDiEnvironment::InterOpWait()
     std::this_thread::sleep_for(m_interOpWaitingTime);
 }
 
-void RouDiEnvironment::CleanupAppResources(const std::string& name)
+void RouDiEnvironment::CleanupAppResources(const ProcessName_t& name)
 {
     m_runtimes.eraseRuntime(name);
 }

--- a/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
+++ b/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
@@ -28,7 +28,7 @@ std::atomic<uint64_t> RuntimeTestInterface::s_currentRouDiContext{0};
 
 std::mutex RuntimeTestInterface::s_runtimeAccessMutex;
 
-std::map<std::string, PoshRuntime*> RuntimeTestInterface::s_runtimes;
+std::map<ProcessName_t, PoshRuntime*> RuntimeTestInterface::s_runtimes;
 
 RuntimeTestInterface::RuntimeTestInterface()
 {
@@ -71,18 +71,18 @@ void RuntimeTestInterface::cleanupRuntimes()
     RuntimeTestInterface::s_currentRouDiContext.operator++(std::memory_order_relaxed);
 }
 
-void RuntimeTestInterface::eraseRuntime(const std::string& f_name)
+void RuntimeTestInterface::eraseRuntime(const ProcessName_t& name)
 {
     std::lock_guard<std::mutex> lock(RuntimeTestInterface::s_runtimeAccessMutex);
-    auto iter = RuntimeTestInterface::s_runtimes.find(f_name);
+    auto iter = RuntimeTestInterface::s_runtimes.find(name);
     if (iter != RuntimeTestInterface::s_runtimes.end())
     {
         delete iter->second;
-        RuntimeTestInterface::s_runtimes.erase(f_name);
+        RuntimeTestInterface::s_runtimes.erase(name);
     }
 }
 
-PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const std::string& f_name)
+PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const ProcessName_t& name)
 {
     std::lock_guard<std::mutex> lock(RuntimeTestInterface::s_runtimeAccessMutex);
 
@@ -93,7 +93,7 @@ PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const std::string& 
         RuntimeTestInterface::t_activeRuntime = nullptr;
     }
 
-    bool isDefaultName{f_name.compare(runtime::DEFAULT_RUNTIME_INSTANCE_NAME) == 0};
+    bool isDefaultName{name.compare(PoshRuntime::defaultRuntimeInstanceName()) == 0};
     bool invalidGetRuntimeAccess{RuntimeTestInterface::t_activeRuntime == nullptr && isDefaultName};
     cxx::Expects(!invalidGetRuntimeAccess);
 
@@ -102,15 +102,15 @@ PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const std::string& 
         return *RuntimeTestInterface::t_activeRuntime;
     }
 
-    auto iter = RuntimeTestInterface::s_runtimes.find(f_name);
+    auto iter = RuntimeTestInterface::s_runtimes.find(name);
     if (iter != RuntimeTestInterface::s_runtimes.end())
     {
         RuntimeTestInterface::t_activeRuntime = iter->second;
     }
     else
     {
-        auto runtimeImpl = new runtime::PoshRuntime(f_name, false);
-        RuntimeTestInterface::s_runtimes.insert({f_name, runtimeImpl});
+        auto runtimeImpl = new runtime::PoshRuntime(name, false);
+        RuntimeTestInterface::s_runtimes.insert({name, runtimeImpl});
 
         RuntimeTestInterface::t_activeRuntime = runtimeImpl;
     }

--- a/iceoryx_posh/source/runtime/posh_runtime.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2019, 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,22 +29,29 @@ namespace iox
 {
 namespace runtime
 {
-std::function<PoshRuntime&(const std::string& name)> PoshRuntime::s_runtimeFactory = PoshRuntime::defaultRuntimeFactory;
+std::function<PoshRuntime&(const ProcessName_t& name)> PoshRuntime::s_runtimeFactory =
+    PoshRuntime::defaultRuntimeFactory;
 
 
-PoshRuntime& PoshRuntime::defaultRuntimeFactory(const std::string& name) noexcept
+PoshRuntime& PoshRuntime::defaultRuntimeFactory(const ProcessName_t& name) noexcept
 {
     static PoshRuntime instance(name);
     return instance;
 }
 
 // singleton access
-PoshRuntime& PoshRuntime::getInstance(const std::string& name) noexcept
+PoshRuntime& PoshRuntime::getInstance(const ProcessName_t& name) noexcept
 {
     return PoshRuntime::s_runtimeFactory(name);
 }
 
-PoshRuntime::PoshRuntime(const std::string& name, const bool doMapSharedMemoryIntoThread) noexcept
+ProcessName_t& PoshRuntime::defaultRuntimeInstanceName() noexcept
+{
+    static ProcessName_t defaultInstanceName = "dummy";
+    return defaultInstanceName;
+}
+
+PoshRuntime::PoshRuntime(const ProcessName_t& name, const bool doMapSharedMemoryIntoThread) noexcept
     : m_appName(verifyInstanceName(name))
     , m_MqInterface(MQ_ROUDI_NAME, name, PROCESS_WAITING_FOR_ROUDI_TIMEOUT)
     , m_ShmInterface(doMapSharedMemoryIntoThread,
@@ -66,34 +73,29 @@ PoshRuntime::~PoshRuntime() noexcept
 }
 
 
-const std::string& PoshRuntime::verifyInstanceName(const std::string& name) noexcept
+const ProcessName_t& PoshRuntime::verifyInstanceName(const ProcessName_t& name) noexcept
 {
     if (name.empty())
     {
         LogError() << "Cannot initialize runtime. Application name must not be empty!";
         std::terminate();
     }
-    else if (name.compare(DEFAULT_RUNTIME_INSTANCE_NAME) == 0)
+    else if (name.compare(defaultRuntimeInstanceName()) == 0)
     {
         LogError() << "Cannot initialize runtime. Application name has not been specified!";
         std::terminate();
     }
-    else if (name.front() != '/')
+    else if (name.c_str()[0] != '/')
     {
         LogError() << "Cannot initialize runtime. Application name " << name
                    << " does not have the required leading slash '/'";
-        std::terminate();
-    }
-    else if (name.length() > MAX_PROCESS_NAME_LENGTH)
-    {
-        LogError() << "Application name has more than 100 characters, including null termination!";
         std::terminate();
     }
 
     return name;
 }
 
-std::string PoshRuntime::getInstanceName() const noexcept
+ProcessName_t PoshRuntime::getInstanceName() const noexcept
 {
     return m_appName;
 }

--- a/iceoryx_posh/source/runtime/posh_runtime_single_process.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_single_process.cpp
@@ -19,13 +19,13 @@ namespace runtime
 {
 constexpr bool DO_NOT_MAP_SHARED_MEMORY_INTO_THREAD{false};
 
-PoshRuntimeSingleProcess::PoshRuntimeSingleProcess(const std::string& name) noexcept
+PoshRuntimeSingleProcess::PoshRuntimeSingleProcess(const ProcessName_t& name) noexcept
     : PoshRuntime(name, DO_NOT_MAP_SHARED_MEMORY_INTO_THREAD)
 {
-    auto currentFactory = PoshRuntime::s_runtimeFactory.target<PoshRuntime& (*)(const std::string&)>();
+    auto currentFactory = PoshRuntime::s_runtimeFactory.target<PoshRuntime& (*)(const ProcessName_t&)>();
     if (currentFactory != nullptr && *currentFactory == PoshRuntime::defaultRuntimeFactory)
     {
-        PoshRuntime::s_runtimeFactory = [&](const std::string&) -> PoshRuntime& {
+        PoshRuntime::s_runtimeFactory = [&](const ProcessName_t&) -> PoshRuntime& {
             return *static_cast<PoshRuntime*>(this);
         };
     }

--- a/iceoryx_posh/test/moduletests/test_capro_service.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_service.cpp
@@ -161,12 +161,6 @@ TEST_F(ServiceDescription_test, operatorAssign)
     EXPECT_TRUE(csdNew == csd1);
 }
 
-TEST_F(ServiceDescription_test, getServiceString)
-{
-    EXPECT_THAT(csd1.getServiceString(), StrEq("Service_0001_0002_0003"));
-    EXPECT_THAT(csd2.getServiceString(), StrEq("Service_0001_FFFF_0003"));
-}
-
 TEST_F(ServiceDescription_test, CreateServiceOnlyDescription)
 {
     ServiceDescription desc1(1u, 2u);

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -66,34 +66,25 @@ bool PoshRuntime_test::m_errorHandlerCalled{false};
 
 TEST_F(PoshRuntime_test, ValidAppName)
 {
-    std::string appName("/valid_name");
+    iox::ProcessName_t appName("/valid_name");
 
     EXPECT_NO_FATAL_FAILURE({ PoshRuntime::getInstance(appName); });
 }
-
-
-TEST_F(PoshRuntime_test, AppNameLength_OutOfLimit)
-{
-    std::string tooLongName(iox::MAX_PROCESS_NAME_LENGTH, 's');
-    tooLongName.insert(0, 1, '/');
-
-    EXPECT_DEATH({ PoshRuntime::getInstance(tooLongName); },
-                 "Application name has more than 100 characters, including null termination!");
-}
-
 
 TEST_F(PoshRuntime_test, MaxAppNameLength)
 {
     std::string maxValidName(iox::MAX_PROCESS_NAME_LENGTH - 1, 's');
     maxValidName.insert(0, 1, '/');
 
-    EXPECT_NO_FATAL_FAILURE({ PoshRuntime::getInstance(maxValidName); });
+    auto& runtime = PoshRuntime::getInstance(iox::ProcessName_t(iox::cxx::TruncateToCapacity, maxValidName));
+
+    EXPECT_THAT(maxValidName, StrEq(runtime.getInstanceName().c_str()));
 }
 
 
 TEST_F(PoshRuntime_test, NoAppName)
 {
-    const std::string invalidAppName("");
+    const iox::ProcessName_t invalidAppName("");
 
     EXPECT_DEATH({ PoshRuntime::getInstance(invalidAppName); },
                  "Cannot initialize runtime. Application name must not be empty!");
@@ -102,7 +93,7 @@ TEST_F(PoshRuntime_test, NoAppName)
 
 TEST_F(PoshRuntime_test, NoLeadingSlashAppName)
 {
-    const std::string invalidAppName = "invalidname";
+    const iox::ProcessName_t invalidAppName = "invalidname";
 
     EXPECT_DEATH(
         { PoshRuntime::getInstance(invalidAppName); },
@@ -123,7 +114,7 @@ TEST_F(PoshRuntime_test, DISABLED_AppNameEmpty)
 
 TEST_F(PoshRuntime_test, GetInstanceNameIsSuccessful)
 {
-    const std::string appname = "/app";
+    const iox::ProcessName_t appname = "/app";
 
     auto& sut = PoshRuntime::getInstance(appname);
 


### PR DESCRIPTION
This PR removes the std::string from the RouDiEnvironment and from the public API from PoshRuntime.
The C binding is adjusted and some bugs were fixed

partly closes #260 