### PR TITLE
Iox #260 remove std string from introspection and use correct ProcessName_t alias everywhere

### DIFF
--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -68,9 +68,9 @@ class PortIntrospection
             SenderInfo() = default;
 
             SenderInfo(typename SenderPort::MemberType_t* portData,
-                       const std::string& name,
+                       const ProcessName_t& name,
                        const capro::ServiceDescription& service,
-                       const std::string& runnable)
+                       const RunnableName_t& runnable)
                 : portData(portData)
                 , name(name)
                 , service(service)
@@ -79,9 +79,9 @@ class PortIntrospection
             }
 
             typename SenderPort::MemberType_t* portData{nullptr};
-            std::string name;
+            ProcessName_t name;
             capro::ServiceDescription service;
-            std::string runnable;
+            RunnableName_t runnable;
 
             using TimePointNs = mepoo::TimePointNs;
             using DurationNs = mepoo::DurationNs;
@@ -100,9 +100,9 @@ class PortIntrospection
             }
 
             ReceiverInfo(typename ReceiverPort::MemberType_t* const portData,
-                         const std::string& name,
+                         const ProcessName_t& name,
                          const capro::ServiceDescription& service,
-                         const std::string& runnable)
+                         const RunnableName_t& runnable)
                 : portData(portData)
                 , name(name)
                 , service(service)
@@ -111,9 +111,9 @@ class PortIntrospection
             }
 
             typename ReceiverPort::MemberType_t* portData{nullptr};
-            std::string name;
+            ProcessName_t name;
             capro::ServiceDescription service;
-            std::string runnable;
+            RunnableName_t runnable;
         };
 
         struct ConnectionInfo
@@ -123,9 +123,9 @@ class PortIntrospection
             }
 
             ConnectionInfo(typename ReceiverPort::MemberType_t* const portData,
-                           const std::string& name,
+                           const ProcessName_t& name,
                            const capro::ServiceDescription& service,
-                           const std::string& runnable)
+                           const RunnableName_t& runnable)
                 : receiverInfo(portData, name, service, runnable)
                 , state(ConnectionState::DEFAULT)
             {
@@ -162,9 +162,9 @@ class PortIntrospection
          * @return returns false if the port could not be added and true otherwise
          */
         bool addSender(typename SenderPort::MemberType_t* port,
-                       const std::string& name,
+                       const ProcessName_t& name,
                        const capro::ServiceDescription& service,
-                       const std::string& runnable);
+                       const RunnableName_t& runnable);
 
 
         /*!
@@ -179,9 +179,9 @@ class PortIntrospection
          * @return returns false if the port could not be added and true otherwise
          */
         bool addReceiver(typename ReceiverPort::MemberType_t* const portData,
-                         const std::string& name,
+                         const ProcessName_t& name,
                          const capro::ServiceDescription& service,
-                         const std::string& runnable);
+                         const RunnableName_t& runnable);
 
         /*!
          * @brief remove a sender port from introspection
@@ -192,7 +192,7 @@ class PortIntrospection
          * @return returns false if the port could not be removed (since it did not exist)
          *              and true otherwise
          */
-        bool removeSender(const std::string& name, const capro::ServiceDescription& service);
+        bool removeSender(const ProcessName_t& name, const capro::ServiceDescription& service);
 
         /*!
          * @brief remove a receiver port from introspection
@@ -203,7 +203,7 @@ class PortIntrospection
          * @return returns false if the port could not be removed (since it did not exist)
          *              and true otherwise
          */
-        bool removeReceiver(const std::string& name, const capro::ServiceDescription& service);
+        bool removeReceiver(const RunnableName_t& name, const capro::ServiceDescription& service);
 
         /*!
          * @brief update the state of any connection identified by the capro id of a given message
@@ -257,11 +257,12 @@ class PortIntrospection
         using ConnectionContainer = FixedSizeContainer<ConnectionInfo, MAX_SUBSCRIBERS>;
 
         // index sender and connections by capro Ids
-        std::map<std::string, typename SenderContainer::Index_t> m_senderMap;
+        std::map<capro::ServiceDescription, typename SenderContainer::Index_t> m_senderMap;
 
         // TODO: replace inner map wih more approriate structure if possible
-        // inner map maps from port names to indices in the ConnectionContainer
-        std::map<std::string, std::map<std::string, typename ConnectionContainer::Index_t>> m_connectionMap;
+        // inner map maps from process names to indices in the ConnectionContainer
+        std::map<capro::ServiceDescription, std::map<ProcessName_t, typename ConnectionContainer::Index_t>>
+            m_connectionMap;
 
         // Rationale: we avoid allocating the objects on the heap but can still use a map
         // to locate/remove them fast(er)
@@ -300,9 +301,9 @@ class PortIntrospection
      * @return returns false if the port could not be added and true otherwise
      */
     bool addSender(typename SenderPort::MemberType_t* port,
-                   const std::string& name,
+                   const ProcessName_t& name,
                    const capro::ServiceDescription& service,
-                   const std::string& runnable);
+                   const RunnableName_t& runnable);
 
     /*!
      * @brief add a receiver port to be tracked by introspection
@@ -316,9 +317,9 @@ class PortIntrospection
      * @return returns false if the port could not be added and true otherwise
      */
     bool addReceiver(typename ReceiverPort::MemberType_t* const portData,
-                     const std::string& name,
+                     const ProcessName_t& name,
                      const capro::ServiceDescription& service,
-                     const std::string& runnable);
+                     const RunnableName_t& runnable);
 
 
     /*!
@@ -330,7 +331,7 @@ class PortIntrospection
      * @return returns false if the port could not be removed (since it did not exist)
      *              and true otherwise
      */
-    bool removeSender(const std::string& name, const capro::ServiceDescription& service);
+    bool removeSender(const ProcessName_t& name, const capro::ServiceDescription& service);
 
     /*!
      * @brief remove a receiver port from introspection
@@ -341,7 +342,7 @@ class PortIntrospection
      * @return returns false if the port could not be removed (since it did not exist)
      *              and true otherwise
      */
-    bool removeReceiver(const std::string& name, const capro::ServiceDescription& service);
+    bool removeReceiver(const ProcessName_t& name, const capro::ServiceDescription& service);
 
     /*!
      * @brief report a capro message to introspection (since this could change the state of active connections)

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.hpp
@@ -203,7 +203,7 @@ class PortIntrospection
          * @return returns false if the port could not be removed (since it did not exist)
          *              and true otherwise
          */
-        bool removeReceiver(const RunnableName_t& name, const capro::ServiceDescription& service);
+        bool removeReceiver(const ProcessName_t& name, const capro::ServiceDescription& service);
 
         /*!
          * @brief update the state of any connection identified by the capro id of a given message

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/introspection/port_introspection.inl
@@ -169,12 +169,11 @@ template <typename SenderPort, typename ReceiverPort>
 bool PortIntrospection<SenderPort, ReceiverPort>::PortData::updateConnectionState(const capro::CaproMessage& message)
 {
     const capro::ServiceDescription& service = message.m_serviceDescription;
-    std::string serviceId = static_cast<cxx::Serialization>(service).toString();
     capro::CaproMessageType messageType = message.m_type;
 
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    auto iter = m_connectionMap.find(serviceId);
+    auto iter = m_connectionMap.find(service);
     if (iter == m_connectionMap.end())
     {
         return false; // no corresponding capro Id ...
@@ -185,10 +184,9 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::updateConnectionStat
     for (auto& pair : map)
     {
         auto& connection = m_connectionContainer[pair.second];
-        auto receiverServiceId = static_cast<cxx::Serialization>(connection.receiverInfo.service).toString();
-        if (serviceId == receiverServiceId)
+        if (service == connection.receiverInfo.service)
         {
-            // should always be true if its in the map stored at this serviceId
+            // should always be true if its in the map stored at this service key
             connection.state = getNextState(connection.state, messageType);
         }
     }
@@ -199,15 +197,13 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::updateConnectionStat
 
 template <typename SenderPort, typename ReceiverPort>
 bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addSender(typename SenderPort::MemberType_t* port,
-                                                                      const std::string& name,
+                                                                      const ProcessName_t& name,
                                                                       const capro::ServiceDescription& service,
-                                                                      const std::string& runnable)
+                                                                      const RunnableName_t& runnable)
 {
-    std::string serviceId = static_cast<cxx::Serialization>(service).toString();
-
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    auto iter = m_senderMap.find(serviceId);
+    auto iter = m_senderMap.find(service);
     if (iter != m_senderMap.end())
         return false;
 
@@ -215,22 +211,20 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addSender(typename S
     if (index < 0)
         return false;
 
-    m_senderMap.insert(std::make_pair(serviceId, index));
+    m_senderMap.insert(std::make_pair(service, index));
 
     // connect sender to all receivers with the same Id
     SenderInfo* sender = m_senderContainer.get(index);
 
     // find corresponding receivers
-    auto connIter = m_connectionMap.find(serviceId);
+    auto connIter = m_connectionMap.find(service);
     if (connIter != m_connectionMap.end())
     {
         auto& map = connIter->second;
         for (auto& pair : map)
         {
             auto& connection = m_connectionContainer[pair.second];
-            // TODO: maybe save the service string instead for efficiency
-            auto receiverServiceId = static_cast<cxx::Serialization>(connection.receiverInfo.service).toString();
-            if (serviceId == receiverServiceId)
+            if (service == connection.receiverInfo.service)
             {
                 connection.senderInfo = sender;
             }
@@ -243,12 +237,10 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addSender(typename S
 
 template <typename SenderPort, typename ReceiverPort>
 bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addReceiver(typename ReceiverPort::MemberType_t* portData,
-                                                                        const std::string& name,
+                                                                        const ProcessName_t& name,
                                                                         const capro::ServiceDescription& service,
-                                                                        const std::string& runnable)
+                                                                        const RunnableName_t& runnable)
 {
-    std::string serviceId = static_cast<cxx::Serialization>(service).toString();
-
     std::lock_guard<std::mutex> lock(m_mutex);
 
     auto index = m_connectionContainer.add(ConnectionInfo(portData, name, service, runnable));
@@ -257,18 +249,18 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addReceiver(typename
         return false;
     }
 
-    auto iter = m_connectionMap.find(serviceId);
+    auto iter = m_connectionMap.find(service);
 
     if (iter == m_connectionMap.end())
     {
-        // serviceId is new, create new map
-        std::map<std::string, typename ConnectionContainer::Index_t> map;
+        // service is new, create new map
+        std::map<ProcessName_t, typename ConnectionContainer::Index_t> map;
         map.insert(std::make_pair(name, index));
-        m_connectionMap.insert(std::make_pair(serviceId, map));
+        m_connectionMap.insert(std::make_pair(service, map));
     }
     else
     {
-        // serviceId exists, add new entry
+        // service exists, add new entry
         // TODO: check existence of key (name)
         auto& map = iter->second;
         map.insert(std::make_pair(name, index));
@@ -276,7 +268,7 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addReceiver(typename
 
     auto& connection = m_connectionContainer[index];
 
-    auto sendIter = m_senderMap.find(serviceId);
+    auto sendIter = m_senderMap.find(service);
     if (sendIter != m_senderMap.end())
     {
         auto sender = m_senderContainer.get(sendIter->second);
@@ -287,14 +279,12 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::addReceiver(typename
 }
 
 template <typename SenderPort, typename ReceiverPort>
-bool PortIntrospection<SenderPort, ReceiverPort>::PortData::removeSender(const std::string& name [[gnu::unused]],
+bool PortIntrospection<SenderPort, ReceiverPort>::PortData::removeSender(const ProcessName_t& name [[gnu::unused]],
                                                                          const capro::ServiceDescription& service)
 {
-    std::string serviceId = static_cast<cxx::Serialization>(service).toString();
-
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    auto iter = m_senderMap.find(serviceId);
+    auto iter = m_senderMap.find(service);
     if (iter == m_senderMap.end())
         return false;
 
@@ -317,14 +307,12 @@ bool PortIntrospection<SenderPort, ReceiverPort>::PortData::removeSender(const s
 }
 
 template <typename SenderPort, typename ReceiverPort>
-bool PortIntrospection<SenderPort, ReceiverPort>::PortData::removeReceiver(const std::string& name,
+bool PortIntrospection<SenderPort, ReceiverPort>::PortData::removeReceiver(const ProcessName_t& name,
                                                                            const capro::ServiceDescription& service)
 {
-    std::string serviceId = static_cast<cxx::Serialization>(service).toString();
-
     std::lock_guard<std::mutex> lock(m_mutex);
 
-    auto iter = m_connectionMap.find(serviceId);
+    auto iter = m_connectionMap.find(service);
     if (iter == m_connectionMap.end())
     {
         return false; // not found and therefore not removed
@@ -433,8 +421,8 @@ void PortIntrospection<SenderPort, ReceiverPort>::PortData::prepareTopic(PortInt
             SenderPort port(senderInfo.portData);
             senderData.m_senderPortID = static_cast<uint64_t>(port.getUniqueID());
             senderData.m_sourceInterface = senderInfo.service.getSourceInterface();
-            senderData.m_name = cxx::string<100>(cxx::TruncateToCapacity, senderInfo.name.c_str());
-            senderData.m_runnable = cxx::string<100>(cxx::TruncateToCapacity, senderInfo.runnable.c_str());
+            senderData.m_name = senderInfo.name;
+            senderData.m_runnable = senderInfo.runnable;
 
             senderData.m_caproInstanceID = senderInfo.service.getInstanceIDString();
             senderData.m_caproServiceID = senderInfo.service.getServiceIDString();
@@ -458,8 +446,8 @@ void PortIntrospection<SenderPort, ReceiverPort>::PortData::prepareTopic(PortInt
                 bool connected = connection.isConnected();
                 auto& receiverInfo = connection.receiverInfo;
 
-                receiverData.m_name = cxx::string<100>(cxx::TruncateToCapacity, receiverInfo.name.c_str());
-                receiverData.m_runnable = cxx::string<100>(cxx::TruncateToCapacity, receiverInfo.runnable.c_str());
+                receiverData.m_name = receiverInfo.name;
+                receiverData.m_runnable = receiverInfo.runnable;
 
                 receiverData.m_caproInstanceID = receiverInfo.service.getInstanceIDString();
                 receiverData.m_caproServiceID = receiverInfo.service.getServiceIDString();
@@ -571,31 +559,31 @@ void PortIntrospection<SenderPort, ReceiverPort>::PortData::setNew(bool value)
 
 template <typename SenderPort, typename ReceiverPort>
 bool PortIntrospection<SenderPort, ReceiverPort>::addSender(typename SenderPort::MemberType_t* port,
-                                                            const std::string& name,
+                                                            const ProcessName_t& name,
                                                             const capro::ServiceDescription& service,
-                                                            const std::string& runnable)
+                                                            const RunnableName_t& runnable)
 {
     return m_portData.addSender(port, name, service, runnable);
 }
 
 template <typename SenderPort, typename ReceiverPort>
 bool PortIntrospection<SenderPort, ReceiverPort>::addReceiver(typename ReceiverPort::MemberType_t* portData,
-                                                              const std::string& name,
+                                                              const ProcessName_t& name,
                                                               const capro::ServiceDescription& service,
-                                                              const std::string& runnable)
+                                                              const RunnableName_t& runnable)
 {
     return m_portData.addReceiver(portData, name, service, runnable);
 }
 
 template <typename SenderPort, typename ReceiverPort>
-bool PortIntrospection<SenderPort, ReceiverPort>::removeSender(const std::string& name,
+bool PortIntrospection<SenderPort, ReceiverPort>::removeSender(const ProcessName_t& name,
                                                                const capro::ServiceDescription& service)
 {
     return m_portData.removeSender(name, service);
 }
 
 template <typename SenderPort, typename ReceiverPort>
-bool PortIntrospection<SenderPort, ReceiverPort>::removeReceiver(const std::string& name,
+bool PortIntrospection<SenderPort, ReceiverPort>::removeReceiver(const ProcessName_t& name,
                                                                  const capro::ServiceDescription& service)
 {
     return m_portData.removeReceiver(name, service);

--- a/iceoryx_posh/source/popo/receiver_port_data.cpp
+++ b/iceoryx_posh/source/popo/receiver_port_data.cpp
@@ -26,7 +26,7 @@ ReceiverPortData::ReceiverPortData() noexcept
 ReceiverPortData::ReceiverPortData(const capro::ServiceDescription& serviceDescription,
                                    const std::string& applicationName,
                                    const MemoryInfo& memoryInfo) noexcept
-    : BasePortData(serviceDescription, iox::cxx::string<100>(iox::cxx::TruncateToCapacity, applicationName))
+    : BasePortData(serviceDescription, ProcessName_t(iox::cxx::TruncateToCapacity, applicationName))
     , m_memoryInfo(memoryInfo)
 {
 }

--- a/iceoryx_posh/source/popo/sender_port_data.cpp
+++ b/iceoryx_posh/source/popo/sender_port_data.cpp
@@ -28,7 +28,7 @@ SenderPortData::SenderPortData(const capro::ServiceDescription& serviceDescripti
                                mepoo::MemoryManager* const memMgr,
                                const std::string& applicationName,
                                const MemoryInfo& memoryInfo) noexcept
-    : BasePortData(serviceDescription, iox::cxx::string<100>(iox::cxx::TruncateToCapacity, applicationName))
+    : BasePortData(serviceDescription, ProcessName_t(iox::cxx::TruncateToCapacity, applicationName))
     , m_memoryMgr(memMgr)
     , m_memoryInfo(memoryInfo)
 {

--- a/iceoryx_posh/source/roudi/port_pool.cpp
+++ b/iceoryx_posh/source/roudi/port_pool.cpp
@@ -46,7 +46,7 @@ PortPool::addInterfacePort(const std::string& applicationName, const capro::Inte
     if (m_portPoolData->m_interfacePortMembers.hasFreeSpace())
     {
         auto interfacePortData = m_portPoolData->m_interfacePortMembers.insert(
-            iox::cxx::string<100>(iox::cxx::TruncateToCapacity, applicationName), interface);
+            ProcessName_t(iox::cxx::TruncateToCapacity, applicationName), interface);
         return cxx::success<popo::InterfacePortData*>(interfacePortData);
     }
     else
@@ -62,7 +62,7 @@ PortPool::addApplicationPort(const std::string& applicationName) noexcept
     if (m_portPoolData->m_applicationPortMembers.hasFreeSpace())
     {
         auto applicationPortData = m_portPoolData->m_applicationPortMembers.insert(
-            iox::cxx::string<100>(iox::cxx::TruncateToCapacity, applicationName));
+            ProcessName_t(iox::cxx::TruncateToCapacity, applicationName));
         return cxx::success<popo::ApplicationPortData*>(applicationPortData);
     }
     else

--- a/iceoryx_posh/source/roudi/roudi_process.cpp
+++ b/iceoryx_posh/source/roudi/roudi_process.cpp
@@ -559,8 +559,8 @@ void ProcessManager::addRunnableForProcess(const ProcessName_t& processName,
     if (nullptr != process)
     {
         runtime::RunnableData* runnable =
-            m_portManager.acquireRunnableData(cxx::string<100>(cxx::TruncateToCapacity, processName),
-                                              cxx::string<100>(cxx::TruncateToCapacity, runnableName));
+            m_portManager.acquireRunnableData(ProcessName_t(cxx::TruncateToCapacity, processName),
+                                              RunnableName_t(cxx::TruncateToCapacity, runnableName));
 
         auto offset = RelativePointer::getOffset(m_mgmtSegmentId, runnable);
 
@@ -569,8 +569,8 @@ void ProcessManager::addRunnableForProcess(const ProcessName_t& processName,
                    << std::to_string(offset) << std::to_string(m_mgmtSegmentId);
 
         process->sendToMQ(sendBuffer);
-        m_processIntrospection->addRunnable(cxx::string<100>(cxx::TruncateToCapacity, processName.c_str()),
-                                            cxx::string<100>(cxx::TruncateToCapacity, runnableName.c_str()));
+        m_processIntrospection->addRunnable(ProcessName_t(cxx::TruncateToCapacity, processName.c_str()),
+                                            RunnableName_t(cxx::TruncateToCapacity, runnableName.c_str()));
         LogDebug() << "Created new runnable " << runnableName << " for application " << processName;
     }
     else

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -74,7 +74,7 @@ class PortUser_IntegrationTest : public Test
             std::stringstream publisherAppName;
             publisherAppName << TEST_PUBLISHER_APP_NAME << i;
 
-            iox::cxx::string<100> processName(TruncateToCapacity, publisherAppName.str().c_str());
+            iox::ProcessName_t processName(TruncateToCapacity, publisherAppName.str().c_str());
 
             m_publisherPortDataVector.emplace_back(TEST_SERVICE_DESCRIPTION, processName, &m_memoryManager);
             m_publisherPortUserVector.emplace_back(&m_publisherPortDataVector.back());

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -51,13 +51,13 @@ class PoshRuntime_test : public Test
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
 
-    const iox::cxx::string<100> m_runtimeName{"/publisher"};
+    const iox::ProcessName_t m_runtimeName{"/publisher"};
     RouDiEnvironment m_roudiEnv{iox::RouDiConfig_t().setDefaults()};
     PoshRuntime* m_runtime{&iox::runtime::PoshRuntime::getInstance(m_runtimeName)};
     MqMessage m_sendBuffer;
     MqMessage m_receiveBuffer;
-    const iox::cxx::string<100> m_runnableName{"testRunnable"};
-    const iox::cxx::string<100> m_invalidRunnableName{"invalidRunnable,"};
+    const iox::RunnableName_t m_runnableName{"testRunnable"};
+    const iox::RunnableName_t m_invalidRunnableName{"invalidRunnable,"};
     static bool m_errorHandlerCalled;
 };
 

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -215,10 +215,10 @@ TEST_F(PortIntrospection_test, sendData_OneSender)
 
     SenderPort_MOCK senderPort;
     auto mockSenderPort = senderPort.details;
-    std::string senderPortName("name");
+    const iox::ProcessName_t senderProcessName("name");
 
     PortData expectedSenderPortData;
-    expectedSenderPortData.m_name = iox::cxx::string<100>(iox::cxx::TruncateToCapacity, senderPortName.c_str());
+    expectedSenderPortData.m_name = senderProcessName;
     expectedSenderPortData.m_caproInstanceID = "1";
     expectedSenderPortData.m_caproServiceID = "2";
     expectedSenderPortData.m_caproEventMethodID = "3";
@@ -247,7 +247,7 @@ TEST_F(PortIntrospection_test, sendData_OneSender)
     senderPortData.m_throughputReadCache = expectedThroughput;
     senderPortData.m_processName = expectedSenderPortData.m_name;
 
-    EXPECT_THAT(m_introspection->addSender(&senderPortData, senderPortName, service, ""), Eq(true));
+    EXPECT_THAT(m_introspection->addSender(&senderPortData, senderProcessName, service, ""), Eq(true));
 
     SenderPort_MOCK::globalDetails = std::make_shared<SenderPort_MOCK::mock_t>();
     SenderPort_MOCK::globalDetails->reserveSampleReturn = throughputTopic->chunkHeader();
@@ -308,23 +308,25 @@ TEST_F(PortIntrospection_test, addAndRemoveSender)
     auto mockPort1 = port1.details;
     auto mockPort2 = port2.details;
 
-    iox::cxx::string<100> name1("name1");
-    iox::cxx::string<100> name2("name2");
+    const iox::ProcessName_t processName1("name1");
+    const iox::ProcessName_t processName2("name2");
+    const iox::RunnableName_t runnableName1("4");
+    const iox::RunnableName_t runnableName2("jkl");
 
     // prepare expected outputs
     PortData expected1;
-    expected1.m_name = name1;
+    expected1.m_name = processName1;
     expected1.m_caproInstanceID = "1";
     expected1.m_caproServiceID = "2";
     expected1.m_caproEventMethodID = "3";
-    expected1.m_runnable = iox::cxx::string<100>("4");
+    expected1.m_runnable = runnableName1;
 
     PortData expected2;
-    expected2.m_name = name2;
+    expected2.m_name = processName2;
     expected2.m_caproInstanceID = "abc";
     expected2.m_caproServiceID = "def";
     expected2.m_caproEventMethodID = "ghi";
-    expected2.m_runnable = iox::cxx::string<100>("jkl");
+    expected2.m_runnable = runnableName2;
 
     // prepare inputs
     iox::capro::ServiceDescription service1(
@@ -337,10 +339,10 @@ TEST_F(PortIntrospection_test, addAndRemoveSender)
     // remark: duplicate sender port insertions are not possible
 
     iox::popo::SenderPortData portData1, portData2;
-    EXPECT_THAT(m_introspection->addSender(&portData1, name1, service1, "4"), Eq(true));
-    EXPECT_THAT(m_introspection->addSender(&portData1, name1, service1, "4"), Eq(false));
-    EXPECT_THAT(m_introspection->addSender(&portData2, name2, service2, "jkl"), Eq(true));
-    EXPECT_THAT(m_introspection->addSender(&portData2, name2, service2, "jkl"), Eq(false));
+    EXPECT_THAT(m_introspection->addSender(&portData1, processName1, service1, runnableName1), Eq(true));
+    EXPECT_THAT(m_introspection->addSender(&portData1, processName1, service1, runnableName1), Eq(false));
+    EXPECT_THAT(m_introspection->addSender(&portData2, processName2, service2, runnableName2), Eq(true));
+    EXPECT_THAT(m_introspection->addSender(&portData2, processName2, service2, runnableName2), Eq(false));
 
     mockPort1->getUniqueIDReturn = 1;
     mockPort2->getUniqueIDReturn = 2;
@@ -373,8 +375,8 @@ TEST_F(PortIntrospection_test, addAndRemoveSender)
 
     // test removal of ports
 
-    EXPECT_THAT(m_introspection->removeSender(name1, service1), Eq(true));
-    EXPECT_THAT(m_introspection->removeSender(name1, service1), Eq(false));
+    EXPECT_THAT(m_introspection->removeSender(processName1, service1), Eq(true));
+    EXPECT_THAT(m_introspection->removeSender(processName1, service1), Eq(false));
 
     m_introspectionAccess.sendPortData();
 
@@ -385,8 +387,8 @@ TEST_F(PortIntrospection_test, addAndRemoveSender)
         EXPECT_THAT(comparePortData(sample->m_senderList[0], expected2), Eq(true));
     }
 
-    EXPECT_THAT(m_introspection->removeSender(name2, service2), Eq(true));
-    EXPECT_THAT(m_introspection->removeSender(name2, service2), Eq(false));
+    EXPECT_THAT(m_introspection->removeSender(processName2, service2), Eq(true));
+    EXPECT_THAT(m_introspection->removeSender(processName2, service2), Eq(false));
 
     m_introspectionAccess.sendPortData();
 
@@ -395,7 +397,7 @@ TEST_F(PortIntrospection_test, addAndRemoveSender)
         ASSERT_THAT(sample->m_receiverList.size(), Eq(0));
     }
 
-    EXPECT_THAT(m_introspection->removeSender(name2, service2), Eq(false));
+    EXPECT_THAT(m_introspection->removeSender(processName2, service2), Eq(false));
 
     m_introspectionAccess.sendPortData();
 
@@ -418,25 +420,27 @@ TEST_F(PortIntrospection_test, addAndRemoveReceiver)
 
     m_senderPortImpl_mock->reserveSampleReturn = chunk->chunkHeader();
 
-    iox::cxx::string<100> name1("name1");
-    iox::cxx::string<100> name2("name2");
+    const iox::ProcessName_t processName1("name1");
+    const iox::ProcessName_t processName2("name2");
+    const iox::RunnableName_t runnableName1("4");
+    const iox::RunnableName_t runnableName2("7");
 
     // prepare expected outputs
     PortData expected1;
-    expected1.m_name = name1;
+    expected1.m_name = processName1;
     expected1.m_caproInstanceID = "1";
     expected1.m_caproServiceID = "2";
     expected1.m_caproEventMethodID = "3";
     expected1.m_senderIndex = -1;
-    expected1.m_runnable = iox::cxx::string<100>("4");
+    expected1.m_runnable = runnableName1;
 
     PortData expected2;
-    expected2.m_name = name2;
+    expected2.m_name = processName2;
     expected2.m_caproInstanceID = "4";
     expected2.m_caproServiceID = "5";
     expected2.m_caproEventMethodID = "6";
     expected2.m_senderIndex = -1;
-    expected2.m_runnable = iox::cxx::string<100>("7");
+    expected2.m_runnable = runnableName2;
 
     // prepare inputs
     iox::capro::ServiceDescription service1(
@@ -449,10 +453,10 @@ TEST_F(PortIntrospection_test, addAndRemoveReceiver)
     // remark: duplicate receiver insertions are possible but will not be transmitted via send
     iox::popo::ReceiverPortData recData1;
     iox::popo::ReceiverPortData recData2;
-    EXPECT_THAT(m_introspection->addReceiver(&recData1, name1, service1, "4"), Eq(true));
-    EXPECT_THAT(m_introspection->addReceiver(&recData1, name1, service1, "4"), Eq(true));
-    EXPECT_THAT(m_introspection->addReceiver(&recData2, name2, service2, "7"), Eq(true));
-    EXPECT_THAT(m_introspection->addReceiver(&recData2, name2, service2, "7"), Eq(true));
+    EXPECT_THAT(m_introspection->addReceiver(&recData1, processName1, service1, runnableName1), Eq(true));
+    EXPECT_THAT(m_introspection->addReceiver(&recData1, processName1, service1, runnableName1), Eq(true));
+    EXPECT_THAT(m_introspection->addReceiver(&recData2, processName2, service2, runnableName2), Eq(true));
+    EXPECT_THAT(m_introspection->addReceiver(&recData2, processName2, service2, runnableName2), Eq(true));
 
     m_introspectionAccess.sendPortData();
 
@@ -482,8 +486,8 @@ TEST_F(PortIntrospection_test, addAndRemoveReceiver)
 
     // test removal of ports
 
-    EXPECT_THAT(m_introspection->removeReceiver(name1, service1), Eq(true));
-    EXPECT_THAT(m_introspection->removeReceiver(name1, service1), Eq(false));
+    EXPECT_THAT(m_introspection->removeReceiver(processName1, service1), Eq(true));
+    EXPECT_THAT(m_introspection->removeReceiver(processName1, service1), Eq(false));
 
     m_introspectionAccess.sendPortData();
 
@@ -496,8 +500,8 @@ TEST_F(PortIntrospection_test, addAndRemoveReceiver)
         EXPECT_THAT(comparePortData(senderInfo, expected2), Eq(true));
     }
 
-    EXPECT_THAT(m_introspection->removeReceiver(name2, service2), Eq(true));
-    EXPECT_THAT(m_introspection->removeReceiver(name2, service2), Eq(false));
+    EXPECT_THAT(m_introspection->removeReceiver(processName2, service2), Eq(true));
+    EXPECT_THAT(m_introspection->removeReceiver(processName2, service2), Eq(false));
 
     m_introspectionAccess.sendPortData();
 
@@ -506,7 +510,7 @@ TEST_F(PortIntrospection_test, addAndRemoveReceiver)
         ASSERT_THAT(sample->m_receiverList.size(), Eq(0));
     }
 
-    EXPECT_THAT(m_introspection->removeReceiver(name2, service2), Eq(false));
+    EXPECT_THAT(m_introspection->removeReceiver(processName2, service2), Eq(false));
 
     m_introspectionAccess.sendPortData();
 
@@ -531,19 +535,19 @@ TEST_F(PortIntrospection_test, reportMessageToEstablishConnection)
 
     m_senderPortImpl_mock->reserveSampleReturn = chunk->chunkHeader();
 
-    std::string nameReceiver("receiver");
-    std::string nameSender("sender");
+    const iox::ProcessName_t receiverProcessName("receiver");
+    const iox::ProcessName_t senderProcessName("sender");
 
     // prepare expected outputs
     ReceiverPortData expectedReceiver;
-    expectedReceiver.m_name = iox::cxx::string<100>(iox::cxx::TruncateToCapacity, nameReceiver.c_str());
+    expectedReceiver.m_name = receiverProcessName;
     expectedReceiver.m_caproInstanceID = "1";
     expectedReceiver.m_caproServiceID = "2";
     expectedReceiver.m_caproEventMethodID = "3";
     expectedReceiver.m_senderIndex = -1;
 
     SenderPortData expectedSender;
-    expectedSender.m_name = iox::cxx::string<100>(iox::cxx::TruncateToCapacity, nameSender.c_str());
+    expectedSender.m_name = senderProcessName;
     expectedSender.m_caproInstanceID = "1";
     expectedSender.m_caproServiceID = "2";
     expectedSender.m_caproEventMethodID = "3";
@@ -555,9 +559,9 @@ TEST_F(PortIntrospection_test, reportMessageToEstablishConnection)
     // test adding of sender and receiver port of same service to establish a connection (requires same service id)
     m_senderPortImpl.details = m_senderPortImpl_mock;
     iox::popo::ReceiverPortData recData1;
-    EXPECT_THAT(m_introspection->addReceiver(&recData1, nameReceiver, service, ""), Eq(true));
+    EXPECT_THAT(m_introspection->addReceiver(&recData1, receiverProcessName, service, ""), Eq(true));
     iox::popo::SenderPortData senderPortData;
-    EXPECT_THAT(m_introspection->addSender(&senderPortData, nameSender, service, ""), Eq(true));
+    EXPECT_THAT(m_introspection->addSender(&senderPortData, senderProcessName, service, ""), Eq(true));
 
     m_senderPortImpl_mock->getUniqueIDReturn = 42;
 

--- a/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_process_introspection.cpp
@@ -122,11 +122,11 @@ TEST_F(ProcessIntrospection_test, addRemoveProcess)
         EXPECT_THAT(chunk1->sample()->m_processList.size(), Eq(0U));
 
         // a new process should be sent
-        m_introspection.addProcess(PID, iox::cxx::string<100>(PROCESS_NAME));
+        m_introspection.addProcess(PID, iox::ProcessName_t(PROCESS_NAME));
         auto chunk2 = createMemoryChunkAndSend(m_introspection);
         EXPECT_THAT(chunk2->sample()->m_processList.size(), Eq(1U));
         EXPECT_THAT(chunk2->sample()->m_processList[0].m_pid, Eq(PID));
-        EXPECT_THAT(iox::cxx::string<100>(PROCESS_NAME) == chunk2->sample()->m_processList[0].m_name, Eq(true));
+        EXPECT_THAT(iox::ProcessName_t(PROCESS_NAME) == chunk2->sample()->m_processList[0].m_name, Eq(true));
 
         // list should be empty after removal
         m_introspection.removeProcess(PID);


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
This PR removes the std::string usage from the PortIntrospection.
Instead of serializing the ServiceDescription to use it as a key for some std::maps, the ServiceDescription is now used itself as key.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- partly closes #260
