### PR TITLE
iox-#388 fixed waitset behavior back to "there are samples in the queue"

### DIFF
--- a/iceoryx_posh/source/popo/wait_set.cpp
+++ b/iceoryx_posh/source/popo/wait_set.cpp
@@ -119,12 +119,9 @@ WaitSet::ConditionVector WaitSet::waitAndReturnFulfilledConditions(const WaitFun
 {
     WaitSet::ConditionVector conditions;
 
-    if (m_conditionVariableWaiter.wasNotified())
-    {
-        /// Inbetween here and last wait someone could have set the trigger to true, hence reset it.
-        m_conditionVariableWaiter.reset();
-        conditions = createVectorWithFullfilledConditions();
-    }
+    /// Inbetween here and last wait someone could have set the trigger to true, hence reset it.
+    m_conditionVariableWaiter.reset();
+    conditions = createVectorWithFullfilledConditions();
 
     // It is possible that after the reset call and before the createVectorWithFullfilledConditions call
     // another trigger came in. Then createVectorWithFullfilledConditions would have already handled it.


### PR DESCRIPTION
Signed-off-by: Christian Eltzschig <me@elchris.org>

## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
<!-- Items in addition to the checklist below that the reviewer should look for -->
This changes the behavior of the waitset back to how it was originally. The `wait` call returns immediately if there are chunks in the queue of a subscriber. I.e. it is a "there is some work todo" waitset. Another version (similar to how it was with this change) could be in future a "there is some new work todo" waitset. Here the wait would return only if there are new samples since the last wait call, independent of how many "old" samples are still in the queue. But so far we are using the first version 
 
## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Closes #388 
