### PR TITLE
Iox #382 remove default param from getInstance

### DIFF
--- a/iceoryx_binding_c/source/c_runtime.cpp
+++ b/iceoryx_binding_c/source/c_runtime.cpp
@@ -34,7 +34,7 @@ void iox_runtime_register(const char* const name)
         std::terminate();
     }
 
-    PoshRuntime::getInstance(ProcessName_t(iox::cxx::TruncateToCapacity, name));
+    PoshRuntime::initRuntime(ProcessName_t(iox::cxx::TruncateToCapacity, name));
 }
 
 uint64_t iox_runtime_get_instance_name(char* const name, const uint64_t nameLength)

--- a/iceoryx_dds/source/dds2iceoryx_app/main.cpp
+++ b/iceoryx_dds/source/dds2iceoryx_app/main.cpp
@@ -58,7 +58,7 @@ int main()
     signal(SIGTERM, ShutdownManager::scheduleShutdown);
 
     // Start application
-    iox::runtime::PoshRuntime::getInstance("/iox-gw-dds2iceoryx");
+    iox::runtime::PoshRuntime::initRuntime("/iox-gw-dds2iceoryx");
 
     iox::dds::DDS2IceoryxGateway<> gw;
 

--- a/iceoryx_dds/source/iceoryx2dds_app/main.cpp
+++ b/iceoryx_dds/source/iceoryx2dds_app/main.cpp
@@ -50,7 +50,7 @@ int main()
     signal(SIGTERM, ShutdownManager::scheduleShutdown);
 
     // Start application
-    iox::runtime::PoshRuntime::getInstance("/iox-gw-iceoryx2dds");
+    iox::runtime::PoshRuntime::initRuntime("/iox-gw-iceoryx2dds");
 
     iox::dds::Iceoryx2DDSGateway<> gw;
 

--- a/iceoryx_examples/icedelivery/README.md
+++ b/iceoryx_examples/icedelivery/README.md
@@ -93,10 +93,10 @@ It is included by:
 
     #include "topic_data.hpp"
 
-For the communication with RouDi a runtime object is created. The parameter of the method `getInstance()` contains a
+For the communication with RouDi a runtime object is created. The parameter of the method `initRuntime()` contains a
 unique string identifier for this publisher.
 
-    iox::runtime::PoshRuntime::getInstance("/publisher-bare-metal");
+    iox::runtime::PoshRuntime::initRuntime("/publisher-bare-metal");
 
 Now that RouDi knows our publisher application is exisiting, let's create a publisher instance and offer our charming struct
 to everyone:
@@ -144,7 +144,7 @@ Similar to the publisher we need to include the runtime and the subscriber as we
 
 To make RouDi aware of the subscriber an runtime object is created, once again with a unique identifier string:
 
-    iox::runtime::PoshRuntime::getInstance("/subscriber-bare-metal");
+    iox::runtime::PoshRuntime::initRuntime("/subscriber-bare-metal");
 
 In the next step a subscriber object is created, matching exactly the `capro::ServiceDescription` that the publisher
 offered:

--- a/iceoryx_examples/icedelivery/ice_publisher_bare_metal.cpp
+++ b/iceoryx_examples/icedelivery/ice_publisher_bare_metal.cpp
@@ -31,7 +31,7 @@ static void sigHandler(int f_sig [[gnu::unused]])
 void sending()
 {
     // Create the runtime for registering with the RouDi daemon
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-publisher-bare-metal");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-publisher-bare-metal");
 
     // Create a publisher
     iox::popo::Publisher myPublisher({"Radar", "FrontLeft", "Counter"});

--- a/iceoryx_examples/icedelivery/ice_publisher_simple.cpp
+++ b/iceoryx_examples/icedelivery/ice_publisher_simple.cpp
@@ -33,7 +33,7 @@ static void sigHandler(int f_sig [[gnu::unused]])
 void sending()
 {
     // Create the runtime for registering with the RouDi daemon
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-publisher-simple");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-publisher-simple");
 
     // create the templateized publisher
     TypedPublisher<CounterTopic> myTypedPublisher({"Radar", "FrontRight", "Counter"});

--- a/iceoryx_examples/icedelivery/ice_subscriber_bare_metal.cpp
+++ b/iceoryx_examples/icedelivery/ice_subscriber_bare_metal.cpp
@@ -31,7 +31,7 @@ static void sigHandler(int f_sig [[gnu::unused]])
 void receiving()
 {
     // Create the runtime for registering with the RouDi daemon
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-subscriber-bare-metal");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-subscriber-bare-metal");
 
     // Create a subscriber
     iox::popo::Subscriber mySubscriber({"Radar", "FrontLeft", "Counter"});

--- a/iceoryx_examples/icedelivery/ice_subscriber_simple.cpp
+++ b/iceoryx_examples/icedelivery/ice_subscriber_simple.cpp
@@ -39,7 +39,7 @@ void myCallback(const CounterTopic& sample)
 void receiving()
 {
     // Create the runtime for registering with the RouDi daemon
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-subscriber-simple");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-subscriber-simple");
 
     // Create the typed subscriber and provide the callback, the rest will be executed in middleware context
     TypedSubscriber<CounterTopic> myTypedSubscriber({"Radar", "FrontRight", "Counter"}, myCallback);

--- a/iceoryx_examples/icedelivery/iox_publisher_typed_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_typed_modern.cpp
@@ -39,7 +39,7 @@ int main()
     // Register sigHandler for SIGINT
     signal(SIGINT, sigHandler);
 
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-publisher-typed-modern");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-publisher-typed-modern");
 
     auto typedPublisher = iox::popo::TypedPublisher<Position>({"Odometry", "Position", "Vehicle"});
     typedPublisher.offer();

--- a/iceoryx_examples/icedelivery/iox_publisher_untyped_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_publisher_untyped_modern.cpp
@@ -34,7 +34,7 @@ int main()
     // Register sigHandler for SIGINT
     signal(SIGINT, sigHandler);
 
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-publisher-untyped-modern");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-publisher-untyped-modern");
 
     auto untypedPublisher = iox::popo::UntypedPublisher({"Odometry", "Position", "Vehicle"});
     untypedPublisher.offer();

--- a/iceoryx_examples/icedelivery/iox_subscriber_typed_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_typed_modern.cpp
@@ -65,7 +65,7 @@ int main()
     signal(SIGINT, sigHandler);
 
     // initialize runtime
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-subscriber-typed-modern");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-subscriber-typed-modern");
 
     // initialized subscribers
     iox::popo::TypedSubscriber<Position> typedSubscriber({"Odometry", "Position", "Vehicle"});

--- a/iceoryx_examples/icedelivery/iox_subscriber_untyped_modern.cpp
+++ b/iceoryx_examples/icedelivery/iox_subscriber_untyped_modern.cpp
@@ -65,7 +65,7 @@ int main()
     signal(SIGINT, sigHandler);
 
     // initialize runtime
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-subscriber-untyped-modern");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-subscriber-untyped-modern");
 
     // initialized subscribers
     iox::popo::UntypedSubscriber untypedSubscriber({"Odometry", "Position", "Vehicle"});

--- a/iceoryx_examples/iceperf/README.md
+++ b/iceoryx_examples/iceperf/README.md
@@ -269,7 +269,7 @@ Now we can create an object for each IPC technology that we want to evaluate and
         leaderDo(uds, numRoundtrips);
 
         std::cout << std::endl << "******      ICEORYX       ********" << std::endl;
-        iox::runtime::PoshRuntime::getInstance(APP_NAME); // runtime for registering with the RouDi daemon
+        iox::runtime::PoshRuntime::initRuntime(APP_NAME); // runtime for registering with the RouDi daemon
         Iceoryx iceoryx(PUBLISHER, SUBSCRIBER);
         leaderDo(iceoryx, numRoundtrips);
 ```

--- a/iceoryx_examples/iceperf/iceperf_hardy.cpp
+++ b/iceoryx_examples/iceperf/iceperf_hardy.cpp
@@ -50,7 +50,7 @@ int main()
     followerDo(uds);
 
     std::cout << std::endl << "******      ICEORYX       ********" << std::endl;
-    iox::runtime::PoshRuntime::getInstance(APP_NAME); // runtime for registering with the RouDi daemon
+    iox::runtime::PoshRuntime::initRuntime(APP_NAME); // runtime for registering with the RouDi daemon
     Iceoryx iceoryx(PUBLISHER, SUBSCRIBER);
     followerDo(iceoryx);
 

--- a/iceoryx_examples/iceperf/iceperf_laurel.cpp
+++ b/iceoryx_examples/iceperf/iceperf_laurel.cpp
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
     leaderDo(uds, numRoundtrips);
 
     std::cout << std::endl << "******      ICEORYX       ********" << std::endl;
-    iox::runtime::PoshRuntime::getInstance(APP_NAME); // runtime for registering with the RouDi daemon
+    iox::runtime::PoshRuntime::initRuntime(APP_NAME); // runtime for registering with the RouDi daemon
     Iceoryx iceoryx(PUBLISHER, SUBSCRIBER);
     leaderDo(iceoryx, numRoundtrips);
 

--- a/iceoryx_examples/waitset/ice_publisher_waitset.cpp
+++ b/iceoryx_examples/waitset/ice_publisher_waitset.cpp
@@ -29,7 +29,7 @@ static void sigHandler(int f_sig [[gnu::unused]])
 
 void sending()
 {
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-publisher-waitset");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-publisher-waitset");
 
     iox::popo::TypedPublisher<CounterTopic> myPublisher({"Radar", "FrontLeft", "Counter"});
     myPublisher.offer();

--- a/iceoryx_examples/waitset/ice_subscriber_waitset.cpp
+++ b/iceoryx_examples/waitset/ice_subscriber_waitset.cpp
@@ -31,7 +31,7 @@ static void sigHandler(int f_sig [[gnu::unused]])
 
 void receiving()
 {
-    iox::runtime::PoshRuntime::getInstance("/iox-ex-subscriber-waitset");
+    iox::runtime::PoshRuntime::initRuntime("/iox-ex-subscriber-waitset");
 
 
     iox::popo::TypedSubscriber<CounterTopic> mySubscriber({"Radar", "FrontLeft", "Counter"});

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
@@ -43,26 +43,26 @@ class RuntimeTestInterface
 
     static std::map<ProcessName_t, runtime::PoshRuntime*> s_runtimes;
 
-    /// This is a replacement for the PoshRuntime::GetInstance factory method
-    /// @param [in] name ist the name of the runtime
+    /// This is a replacement for the PoshRuntime::getInstance factory method
+    /// @param [in] name is an optional containing the name of the runtime
     /// @return a reference to a PoshRuntime
     /// @note The runtime is stored in a vector and a thread local storage.
     ///
     ///       In a multithreaded environment each thread has its own runtime. This means that for each thread
-    ///       iox::runtime::PoshRuntime::GetInstance(...) must be called. Threads that call GetInstance(...)
+    ///       iox::runtime::PoshRuntime::getInstance(...) must be called. Threads that call getInstance(...)
     ///       with the same name, share the same runtime.
     ///
     ///       It is also possible to use multiple runtimes in a singlethreaded environment. There are some points to
-    ///       take care of, though.  There are some classes that call PoshRuntime::GetInstance() without a
+    ///       take care of, though.  There are some classes that call PoshRuntime::getInstance() without a
     ///       parameter. In this case the already created runtime is used. In the context of the roudi environment this
     ///       means that the active runtime is used. The active runtime is the one from the latest
-    ///       iox::runtime::PoshRuntimeImp::GetInstance(...) call with a parameter.
-    ///       Places where a GetInstance() call without parameter happens are:
+    ///       iox::runtime::PoshRuntime::getInstance(...) call with a parameter.
+    ///       Places where a getInstance() call without parameter happens are:
     ///         - constructors of Publisher, Subscriber and GatewayGeneric
     ///         - FindService, OfferService and StopOfferService
-    ///       This means that iox::runtime::PoshRuntimeImp::GetInstance(...) must be called before the above classes
+    ///       This means that iox::runtime::PoshRuntime::initRuntime(...) must be called before the above classes
     ///       are created or functions are called, to make the correct runtime active.
-    static runtime::PoshRuntime& runtimeFactoryGetInstance(const ProcessName_t& name);
+    static runtime::PoshRuntime& runtimeFactoryGetInstance(cxx::optional<const ProcessName_t*> name);
 
   public:
     RuntimeTestInterface(RuntimeTestInterface&& rhs);

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
@@ -49,15 +49,15 @@ class RuntimeTestInterface
     /// @note The runtime is stored in a vector and a thread local storage.
     ///
     ///       In a multithreaded environment each thread has its own runtime. This means that for each thread
-    ///       iox::runtime::PoshRuntime::getInstance(...) must be called. Threads that call getInstance(...)
+    ///       iox::runtime::PoshRuntime::initRuntime(...) must be called. Threads that call initRuntime(...)
     ///       with the same name, share the same runtime.
     ///
     ///       It is also possible to use multiple runtimes in a singlethreaded environment. There are some points to
-    ///       take care of, though.  There are some classes that call PoshRuntime::getInstance() without a
-    ///       parameter. In this case the already created runtime is used. In the context of the roudi environment this
+    ///       take care of, though.  There are some classes that call PoshRuntime::getInstance() parameter. In this
+    ///       case the already created runtime is used. In the context of the roudi environment this
     ///       means that the active runtime is used. The active runtime is the one from the latest
-    ///       iox::runtime::PoshRuntime::getInstance(...) call with a parameter.
-    ///       Places where a getInstance() call without parameter happens are:
+    ///       iox::runtime::PoshRuntime::initRuntime(...) call.
+    ///       Places where a getInstance() call happens are:
     ///         - constructors of Publisher, Subscriber and GatewayGeneric
     ///         - FindService, OfferService and StopOfferService
     ///       This means that iox::runtime::PoshRuntime::initRuntime(...) must be called before the above classes

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi_environment/runtime_test_interface.hpp
@@ -53,7 +53,7 @@ class RuntimeTestInterface
     ///       with the same name, share the same runtime.
     ///
     ///       It is also possible to use multiple runtimes in a singlethreaded environment. There are some points to
-    ///       take care of, though.  There are some classes that call PoshRuntime::getInstance() parameter. In this
+    ///       take care of, though.  There are some classes that call PoshRuntime::getInstance(). In this
     ///       case the already created runtime is used. In the context of the roudi environment this
     ///       means that the active runtime is used. The active runtime is the one from the latest
     ///       iox::runtime::PoshRuntime::initRuntime(...) call.

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -53,7 +53,10 @@ class PoshRuntime
   public:
     /// @brief creates the runtime or return the already existing one -> Singleton
     /// @param[in] name name that is used for registering the process with the RouDi daemon
-    static PoshRuntime& getInstance(const ProcessName_t& name = defaultRuntimeInstanceName()) noexcept;
+    [[deprecated]] static PoshRuntime& getInstance(const ProcessName_t& name = defaultRuntimeInstanceName()) noexcept;
+
+
+    static PoshRuntime& initRuntime(const ProcessName_t& name) noexcept;
 
     /// @brief get the name that was used to register with RouDi
     /// @return name of the reistered application

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -53,8 +53,9 @@ class PoshRuntime
   public:
     /// @brief creates the runtime or return the already existing one -> Singleton
     /// @param[in] name name that is used for registering the process with the RouDi daemon
-    [[deprecated]] static PoshRuntime& getInstance(const ProcessName_t& name = defaultRuntimeInstanceName()) noexcept;
+    [[deprecated]] static PoshRuntime& getInstance(const ProcessName_t& name) noexcept;
 
+    static PoshRuntime& getInstance() noexcept;
 
     static PoshRuntime& initRuntime(const ProcessName_t& name) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -55,12 +55,20 @@ class PoshRuntime
     /// @param[in] name name that is used for registering the process with the RouDi daemon
     [[deprecated]] static PoshRuntime& getInstance(const ProcessName_t& name) noexcept;
 
+    /// @brief returns active runtime
+    ///
+    /// @return active runtime
     static PoshRuntime& getInstance() noexcept;
 
+    /// @brief creates the runtime with given name
+    ///
+    /// @param[in] name used for registering the process with the RouDi daemon
+    ///
+    /// @return active runtime
     static PoshRuntime& initRuntime(const ProcessName_t& name) noexcept;
 
     /// @brief get the name that was used to register with RouDi
-    /// @return name of the reistered application
+    /// @return name of the registered application
     ProcessName_t getInstanceName() const noexcept;
 
     /// @brief find all services that match the provided service description
@@ -170,12 +178,12 @@ class PoshRuntime
     friend class roudi::RuntimeTestInterface;
 
   protected:
-    using factory_t = PoshRuntime& (*)(const ProcessName_t&);
+    using factory_t = PoshRuntime& (*)(cxx::optional<const ProcessName_t*>);
 
     // Protected constructor for IPC setup
-    PoshRuntime(const ProcessName_t& name, const bool doMapSharedMemoryIntoThread = true) noexcept;
+    PoshRuntime(cxx::optional<const ProcessName_t*> name, const bool doMapSharedMemoryIntoThread = true) noexcept;
 
-    static PoshRuntime& defaultRuntimeFactory(const ProcessName_t& name) noexcept;
+    static PoshRuntime& defaultRuntimeFactory(cxx::optional<const ProcessName_t*> name) noexcept;
 
     static ProcessName_t& defaultRuntimeInstanceName() noexcept;
 
@@ -189,6 +197,13 @@ class PoshRuntime
     ///
     /// @param[in] factory std::function to which the runtime factory should be set
     static void setRuntimeFactory(const factory_t& factory) noexcept;
+
+    /// @brief creates the runtime or returns the already existing one -> Singleton
+    ///
+    /// @param[in] name optional containing the name used for registering with the RouDi daemon
+    ///
+    /// @return active runtime
+    static PoshRuntime& getInstance(cxx::optional<const ProcessName_t*> name) noexcept;
 
   private:
     /// @deprecated #25
@@ -209,7 +224,7 @@ class PoshRuntime
 
     /// @brief checks the given application name for certain constraints like length(100 chars) or leading slash
     /// @todo replace length check with fixedstring when its integrated
-    const ProcessName_t& verifyInstanceName(const ProcessName_t& name) noexcept;
+    const ProcessName_t& verifyInstanceName(cxx::optional<const ProcessName_t*> name) noexcept;
 
     const ProcessName_t m_appName;
     mutable std::mutex m_appMqRequestMutex;

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -51,10 +51,6 @@ class RunnableData;
 class PoshRuntime
 {
   public:
-    /// @brief creates the runtime or return the already existing one -> Singleton
-    /// @param[in] name name that is used for registering the process with the RouDi daemon
-    [[deprecated]] static PoshRuntime& getInstance(const ProcessName_t& name) noexcept;
-
     /// @brief returns active runtime
     ///
     /// @return active runtime

--- a/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
+++ b/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
@@ -102,12 +102,6 @@ PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(cxx::optional<const
         return *RuntimeTestInterface::t_activeRuntime;
     }
 
-    // if (nameIsNullopt)
-    //{
-    // ProcessName_t* emptyName;
-    // name.emplace(emptyName);
-    //}
-
     auto iter = RuntimeTestInterface::s_runtimes.find(*name.value());
     if (iter != RuntimeTestInterface::s_runtimes.end())
     {

--- a/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
+++ b/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
@@ -82,7 +82,7 @@ void RuntimeTestInterface::eraseRuntime(const ProcessName_t& name)
     }
 }
 
-PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const ProcessName_t& name)
+PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(cxx::optional<const ProcessName_t*> name)
 {
     std::lock_guard<std::mutex> lock(RuntimeTestInterface::s_runtimeAccessMutex);
 
@@ -93,16 +93,22 @@ PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const ProcessName_t
         RuntimeTestInterface::t_activeRuntime = nullptr;
     }
 
-    bool isDefaultName{name.compare(PoshRuntime::defaultRuntimeInstanceName()) == 0};
-    bool invalidGetRuntimeAccess{RuntimeTestInterface::t_activeRuntime == nullptr && isDefaultName};
+    bool nameIsNullopt{!name.has_value()};
+    bool invalidGetRuntimeAccess{RuntimeTestInterface::t_activeRuntime == nullptr && nameIsNullopt};
     cxx::Expects(!invalidGetRuntimeAccess);
 
-    if (RuntimeTestInterface::t_activeRuntime != nullptr && isDefaultName)
+    if (RuntimeTestInterface::t_activeRuntime != nullptr && nameIsNullopt)
     {
         return *RuntimeTestInterface::t_activeRuntime;
     }
 
-    auto iter = RuntimeTestInterface::s_runtimes.find(name);
+    if (nameIsNullopt)
+    {
+        ProcessName_t* emptyName;
+        name.emplace(emptyName);
+    }
+
+    auto iter = RuntimeTestInterface::s_runtimes.find(*name.value());
     if (iter != RuntimeTestInterface::s_runtimes.end())
     {
         RuntimeTestInterface::t_activeRuntime = iter->second;
@@ -110,7 +116,7 @@ PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(const ProcessName_t
     else
     {
         auto runtimeImpl = new runtime::PoshRuntime(name, false);
-        RuntimeTestInterface::s_runtimes.insert({name, runtimeImpl});
+        RuntimeTestInterface::s_runtimes.insert({*name.value(), runtimeImpl});
 
         RuntimeTestInterface::t_activeRuntime = runtimeImpl;
     }

--- a/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
+++ b/iceoryx_posh/source/roudi_environment/runtime_test_interface.cpp
@@ -102,11 +102,11 @@ PoshRuntime& RuntimeTestInterface::runtimeFactoryGetInstance(cxx::optional<const
         return *RuntimeTestInterface::t_activeRuntime;
     }
 
-    if (nameIsNullopt)
-    {
-        ProcessName_t* emptyName;
-        name.emplace(emptyName);
-    }
+    // if (nameIsNullopt)
+    //{
+    // ProcessName_t* emptyName;
+    // name.emplace(emptyName);
+    //}
 
     auto iter = RuntimeTestInterface::s_runtimes.find(*name.value());
     if (iter != RuntimeTestInterface::s_runtimes.end())

--- a/iceoryx_posh/source/runtime/posh_runtime.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime.cpp
@@ -55,11 +55,6 @@ PoshRuntime& PoshRuntime::defaultRuntimeFactory(cxx::optional<const ProcessName_
 }
 
 // singleton access
-PoshRuntime& PoshRuntime::getInstance(const ProcessName_t& name) noexcept
-{
-    return getInstance(cxx::make_optional<const ProcessName_t*>(&name));
-}
-
 PoshRuntime& PoshRuntime::getInstance() noexcept
 {
     return getInstance(cxx::nullopt);

--- a/iceoryx_posh/source/runtime/posh_runtime.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime.cpp
@@ -60,6 +60,11 @@ PoshRuntime& PoshRuntime::getInstance(const ProcessName_t& name) noexcept
     return getRuntimeFactory()(name);
 }
 
+PoshRuntime& PoshRuntime::initRuntime(const ProcessName_t& name) noexcept
+{
+    return getRuntimeFactory()(name);
+}
+
 ProcessName_t& PoshRuntime::defaultRuntimeInstanceName() noexcept
 {
     static ProcessName_t defaultInstanceName = "dummy";

--- a/iceoryx_posh/source/runtime/posh_runtime.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime.cpp
@@ -101,12 +101,12 @@ const ProcessName_t& PoshRuntime::verifyInstanceName(cxx::optional<const Process
 {
     if (!name.has_value())
     {
-        LogError() << "Cannot initialize runtime. Application name must not be empty!";
+        LogError() << "Cannot initialize runtime. Application name has not been specified!";
         std::terminate();
     }
     else if (name.value()->empty())
     {
-        LogError() << "Cannot initialize runtime. Application name has not been specified!";
+        LogError() << "Cannot initialize runtime. Application name must not be empty!";
         std::terminate();
     }
     else if (name.value()->c_str()[0] != '/')

--- a/iceoryx_posh/source/runtime/posh_runtime.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime.cpp
@@ -60,6 +60,11 @@ PoshRuntime& PoshRuntime::getInstance(const ProcessName_t& name) noexcept
     return getRuntimeFactory()(name);
 }
 
+PoshRuntime& PoshRuntime::getInstance() noexcept
+{
+    return getRuntimeFactory()(ProcessName_t("dummy"));
+}
+
 PoshRuntime& PoshRuntime::initRuntime(const ProcessName_t& name) noexcept
 {
     return getRuntimeFactory()(name);

--- a/iceoryx_posh/source/runtime/posh_runtime_single_process.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime_single_process.cpp
@@ -25,13 +25,13 @@ PoshRuntime*& getSingleProcessRuntime()
     return singleProcessRuntime;
 }
 
-PoshRuntime& singleProcessRuntimeFactory(const ProcessName_t&)
+PoshRuntime& singleProcessRuntimeFactory(cxx::optional<const ProcessName_t*>)
 {
     return *getSingleProcessRuntime();
 }
 
 PoshRuntimeSingleProcess::PoshRuntimeSingleProcess(const ProcessName_t& name) noexcept
-    : PoshRuntime(name, DO_NOT_MAP_SHARED_MEMORY_INTO_THREAD)
+    : PoshRuntime(cxx::make_optional<const ProcessName_t*>(&name), DO_NOT_MAP_SHARED_MEMORY_INTO_THREAD)
 {
     auto currentFactory = PoshRuntime::getRuntimeFactory();
     if (currentFactory != nullptr && *currentFactory == PoshRuntime::defaultRuntimeFactory)

--- a/iceoryx_posh/test/integrationtests/service_discovery/test_roudi_findservice.cpp
+++ b/iceoryx_posh/test/integrationtests/service_discovery/test_roudi_findservice.cpp
@@ -25,8 +25,8 @@ class RoudiFindService_test : public RouDiServiceDiscoveryTest
     {
     }
 
-    iox::runtime::PoshRuntime* senderRuntime{&iox::runtime::PoshRuntime::getInstance("/sender")};
-    iox::runtime::PoshRuntime* receiverRuntime{&iox::runtime::PoshRuntime::getInstance("/receiver")};
+    iox::runtime::PoshRuntime* senderRuntime{&iox::runtime::PoshRuntime::initRuntime("/sender")};
+    iox::runtime::PoshRuntime* receiverRuntime{&iox::runtime::PoshRuntime::initRuntime("/receiver")};
 };
 
 TEST_F(RoudiFindService_test, OfferSingleMethodServiceSingleInstance)

--- a/iceoryx_posh/test/integrationtests/test_interface_port_stack_blowup.cpp
+++ b/iceoryx_posh/test/integrationtests/test_interface_port_stack_blowup.cpp
@@ -33,7 +33,7 @@ class InterfacePortRequestStackBlowup_test : public RouDi_GTest
 
 TEST_F(InterfacePortRequestStackBlowup_test, RouDiMustContinue)
 {
-    iox::runtime::PoshRuntime::initRuntime("/inteface_port_request_stack_blowup");
+    iox::runtime::PoshRuntime::initRuntime("/interface_port_request_stack_blowup");
     GatewayBase sut(iox::capro::Interfaces::INTERNAL);
     iox::capro::CaproMessage caproMessage;
     // we don't care if there are capro messages or not, we just want to have a check that there was no segfault

--- a/iceoryx_posh/test/integrationtests/test_interface_port_stack_blowup.cpp
+++ b/iceoryx_posh/test/integrationtests/test_interface_port_stack_blowup.cpp
@@ -33,7 +33,7 @@ class InterfacePortRequestStackBlowup_test : public RouDi_GTest
 
 TEST_F(InterfacePortRequestStackBlowup_test, RouDiMustContinue)
 {
-    iox::runtime::PoshRuntime::getInstance("/inteface_port_request_stack_blowup");
+    iox::runtime::PoshRuntime::initRuntime("/inteface_port_request_stack_blowup");
     GatewayBase sut(iox::capro::Interfaces::INTERNAL);
     iox::capro::CaproMessage caproMessage;
     // we don't care if there are capro messages or not, we just want to have a check that there was no segfault

--- a/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
+++ b/iceoryx_posh/test/integrationtests/test_posh_mepoo.cpp
@@ -143,10 +143,10 @@ class Mepoo_IntegrationTest : public Test
 
         iox::capro::ServiceDescription m_service_description{99, 1, 20};
 
-        auto& senderRuntime = iox::runtime::PoshRuntime::getInstance("/sender");
+        auto& senderRuntime = iox::runtime::PoshRuntime::initRuntime("/sender");
         senderPort = iox::popo::SenderPort(senderRuntime.getMiddlewareSender(m_service_description));
 
-        auto& receiverRuntime = iox::runtime::PoshRuntime::getInstance("/receiver");
+        auto& receiverRuntime = iox::runtime::PoshRuntime::initRuntime("/receiver");
         receiverPort = iox::popo::ReceiverPort(receiverRuntime.getMiddlewareReceiver(m_service_description));
     }
 

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -117,7 +117,7 @@ TEST_F(PoshRuntime_test, NoAppName)
     const iox::ProcessName_t invalidAppName("");
 
     EXPECT_DEATH({ PoshRuntime::initRuntime(invalidAppName); },
-                 "Cannot initialize runtime. Application name has not been specified!");
+                 "Cannot initialize runtime. Application name must not be empty!");
 }
 
 
@@ -137,7 +137,7 @@ TEST_F(PoshRuntime_test, NoLeadingSlashAppName)
 TEST(PoshRuntime, AppNameEmpty)
 {
     EXPECT_DEATH({ iox::runtime::PoshRuntime::getInstance(); },
-                 "Cannot initialize runtime. Application name must not be empty!");
+                 "Cannot initialize runtime. Application name has not been specified!");
 }
 
 

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -72,7 +72,7 @@ class PoshRuntime_test : public Test
         std::string output = internal::GetCapturedStdout();
         if (Test::HasFailure())
         {
-           std::cout << output << std::endl;
+            std::cout << output << std::endl;
         }
     };
 
@@ -83,7 +83,7 @@ class PoshRuntime_test : public Test
 
     const iox::ProcessName_t m_runtimeName{"/publisher"};
     RouDiEnvironment m_roudiEnv{iox::RouDiConfig_t().setDefaults()};
-    PoshRuntime* m_runtime{&iox::runtime::PoshRuntime::getInstance(m_runtimeName)};
+    PoshRuntime* m_runtime{&iox::runtime::PoshRuntime::initRuntime(m_runtimeName)};
     MqMessage m_sendBuffer;
     MqMessage m_receiveBuffer;
     const iox::RunnableName_t m_runnableName{"testRunnable"};
@@ -98,7 +98,7 @@ TEST_F(PoshRuntime_test, ValidAppName)
 {
     iox::ProcessName_t appName("/valid_name");
 
-    EXPECT_NO_FATAL_FAILURE({ PoshRuntime::getInstance(appName); });
+    EXPECT_NO_FATAL_FAILURE({ PoshRuntime::initRuntime(appName); });
 }
 
 TEST_F(PoshRuntime_test, MaxAppNameLength)
@@ -106,7 +106,7 @@ TEST_F(PoshRuntime_test, MaxAppNameLength)
     std::string maxValidName(iox::MAX_PROCESS_NAME_LENGTH, 's');
     maxValidName.front() = '/';
 
-    auto& runtime = PoshRuntime::getInstance(iox::ProcessName_t(iox::cxx::TruncateToCapacity, maxValidName));
+    auto& runtime = PoshRuntime::initRuntime(iox::ProcessName_t(iox::cxx::TruncateToCapacity, maxValidName));
 
     EXPECT_THAT(maxValidName, StrEq(runtime.getInstanceName().c_str()));
 }
@@ -116,7 +116,7 @@ TEST_F(PoshRuntime_test, NoAppName)
 {
     const iox::ProcessName_t invalidAppName("");
 
-    EXPECT_DEATH({ PoshRuntime::getInstance(invalidAppName); },
+    EXPECT_DEATH({ PoshRuntime::initRuntime(invalidAppName); },
                  "Cannot initialize runtime. Application name must not be empty!");
 }
 
@@ -126,7 +126,7 @@ TEST_F(PoshRuntime_test, NoLeadingSlashAppName)
     const iox::ProcessName_t invalidAppName = "invalidname";
 
     EXPECT_DEATH(
-        { PoshRuntime::getInstance(invalidAppName); },
+        { PoshRuntime::initRuntime(invalidAppName); },
         "Cannot initialize runtime. Application name invalidname does not have the required leading slash '/'");
 }
 
@@ -146,7 +146,7 @@ TEST_F(PoshRuntime_test, GetInstanceNameIsSuccessful)
 {
     const iox::ProcessName_t appname = "/app";
 
-    auto& sut = PoshRuntime::getInstance(appname);
+    auto& sut = PoshRuntime::initRuntime(appname);
 
     EXPECT_EQ(sut.getInstanceName(), appname);
 }
@@ -527,7 +527,7 @@ TEST_F(PoshRuntime_test, CreateRunnableReturnValue)
 TEST_F(PoshRuntime_test, SetValidRuntimeFactorySucceeds)
 {
     PoshRuntimeTestAccess::setRuntimeFactory(testFactory);
-    PoshRuntimeTestAccess::getInstance("/instance");
+    PoshRuntimeTestAccess::initRuntime("/instance");
 
     EXPECT_TRUE(callbackWasCalled);
 }

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -28,7 +28,7 @@ class PoshRuntimeTestAccess : public PoshRuntime
     using PoshRuntime::factory_t;
     using PoshRuntime::setRuntimeFactory;
 
-    PoshRuntimeTestAccess(const iox::ProcessName_t& s)
+    PoshRuntimeTestAccess(iox::cxx::optional<const iox::ProcessName_t*> s)
         : PoshRuntime(s)
     {
     }
@@ -43,7 +43,7 @@ class PoshRuntimeTestAccess : public PoshRuntime
 namespace
 {
 bool callbackWasCalled = false;
-PoshRuntime& testFactory(const iox::ProcessName_t&)
+PoshRuntime& testFactory(iox::cxx::optional<const iox::ProcessName_t*>)
 {
     callbackWasCalled = true;
     return *PoshRuntimeTestAccess::getTestRuntime();
@@ -117,7 +117,7 @@ TEST_F(PoshRuntime_test, NoAppName)
     const iox::ProcessName_t invalidAppName("");
 
     EXPECT_DEATH({ PoshRuntime::initRuntime(invalidAppName); },
-                 "Cannot initialize runtime. Application name must not be empty!");
+                 "Cannot initialize runtime. Application name has not been specified!");
 }
 
 
@@ -131,14 +131,13 @@ TEST_F(PoshRuntime_test, NoLeadingSlashAppName)
 }
 
 
-// since getInstance is a singleton and test class creates instance of Poshruntime,
-// when getInstance() is called without parameterx it reuturns extisting instance
-// To be able to test this, it needs to be the very first call to getInstance but since,
-// we have multiple tests in this binary its not possible here to test
-TEST_F(PoshRuntime_test, DISABLED_AppNameEmpty)
+// since getInstance is a singleton and test class creates instance of Poshruntime
+// when getInstance() is called without parameter, it returns existing instance
+// To be able to test this, we don't use the test fixture
+TEST(PoshRuntime, AppNameEmpty)
 {
     EXPECT_DEATH({ iox::runtime::PoshRuntime::getInstance(); },
-                 "Cannot initialize runtime. Application name has not been specified!");
+                 "Cannot initialize runtime. Application name must not be empty!");
 }
 
 

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -606,7 +606,7 @@ IntrospectionApp::composeReceiverPortData(const PortIntrospectionFieldTopic* por
 void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodMs,
                                         const IntrospectionSelection introspectionSelection)
 {
-    iox::runtime::PoshRuntime::getInstance(iox::roudi::INTROSPECTION_MQ_APP_NAME);
+    iox::runtime::PoshRuntime::initRuntime(iox::roudi::INTROSPECTION_MQ_APP_NAME);
 
     using namespace iox::roudi;
 


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
This PR removes the default parameter from PoshRuntime::getInstance(). Therefore two new functions are introduced: 
getInstance without parameter to receive the active runtime and initRuntime to create the runtime

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Closes [#382](https://github.com/eclipse/iceoryx/issues/382)
