### PR TITLE
iox-#327 Add on demand function loader for system function mocks

### DIFF
--- a/iceoryx_utils/testutils/mocks/mocks.hpp
+++ b/iceoryx_utils/testutils/mocks/mocks.hpp
@@ -31,6 +31,15 @@ template <typename T>
 T assignSymbol(const std::string& functionName);
 } // namespace mocks
 
+#define STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(type, functionName)                                                       \
+    []() {                                                                                                             \
+        static auto returnValue = mocks::assignSymbol<type>(#functionName);                                            \
+        return returnValue;                                                                                            \
+    }()
+
+#define STATIC_FUNCTION_LOADER_AUTO_DEDUCE(functionName)                                                               \
+    STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(decltype(&functionName), functionName)
+
 #include "mocks.inl"
 
 #endif // IOX_UTILS_MOCKS_MOCKS_HPP

--- a/iceoryx_utils/testutils/mocks/mqueue_mock.cpp
+++ b/iceoryx_utils/testutils/mocks/mqueue_mock.cpp
@@ -21,43 +21,29 @@
 std::unique_ptr<mqueue_MOCK> mqueue_MOCK::mock;
 bool mqueue_MOCK::doUseMock = false;
 
-namespace mqueue_orig
-{
-mqd_t (*mq_open)(const char*, int, mode_t, struct mq_attr*) =
-    mocks::assignSymbol<mqd_t (*)(const char*, int, mode_t, struct mq_attr*)>("mq_open");
-mqd_t (*mq_open2)(const char*, int) = mocks::assignSymbol<mqd_t (*)(const char*, int)>("mq_open");
-int (*mq_unlink)(const char*) = mocks::assignSymbol<int (*)(const char*)>("mq_unlink");
-int (*mq_close)(int) = mocks::assignSymbol<int (*)(int)>("mq_close");
-ssize_t (*mq_receive)(int, char*, size_t, unsigned int*) =
-    mocks::assignSymbol<ssize_t (*)(int, char*, size_t, unsigned int*)>("mq_receive");
-ssize_t (*mq_timedreceive)(int, char*, size_t, unsigned int*, const struct timespec*) =
-    mocks::assignSymbol<ssize_t (*)(int, char*, size_t, unsigned int*, const struct timespec*)>("mq_timedreceive");
-int (*mq_send)(int,
-               const char*,
-               size_t,
-               unsigned int) = mocks::assignSymbol<int (*)(int, const char*, size_t, unsigned int)>("mq_send");
-int (*mq_timedsend)(int, const char*, size_t, unsigned int, const struct timespec*) =
-    mocks::assignSymbol<int (*)(int, const char*, size_t, unsigned int, const struct timespec*)>("mq_timedsend");
-} // namespace mqueue_orig
-
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
 int mq_unlink(const char* name)
 #else
 int mq_unlink(const char* name) throw()
 #endif
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_unlink(name) : mqueue_orig::mq_unlink(name);
+    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_unlink(name)
+                                    : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_unlink)(name);
 }
 
 mqd_t mq_open(const char* name, int oflag, mode_t mode, struct mq_attr* attr)
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_open(name, oflag, mode, attr)
-                                    : mqueue_orig::mq_open(name, oflag, mode, attr);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_open(name, oflag, mode, attr)
+               : STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(mqd_t(*)(const char*, int, mode_t, struct mq_attr*),
+                                                      mq_open)(name, oflag, mode, attr);
 }
 
 mqd_t mq_open(const char* name, int oflag)
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_open(name, oflag) : mqueue_orig::mq_open2(name, oflag);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_open(name, oflag)
+               : STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(mqd_t(*)(const char*, int), mq_open2)(name, oflag);
 }
 
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
@@ -66,33 +52,35 @@ int mq_close(int i)
 int mq_close(int i) throw()
 #endif
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_close(i) : mqueue_orig::mq_close(i);
+    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_close(i) : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_close)(i);
 }
 
 ssize_t mq_receive(int mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio)
 {
     return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_receive(mqdes, msg_ptr, msg_len, msg_prio)
-                                    : mqueue_orig::mq_receive(mqdes, msg_ptr, msg_len, msg_prio);
+                                    : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_receive)(mqdes, msg_ptr, msg_len, msg_prio);
 }
 
 ssize_t
 mq_timedreceive(int mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio, const struct timespec* abs_timeout)
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
-                                    : mqueue_orig::mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
+               : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_timedreceive)(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
 }
 
 int mq_send(int mqdes, const char* msg_ptr, size_t msg_len, unsigned int msg_prio)
 {
     return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_send(mqdes, msg_ptr, msg_len, msg_prio)
-                                    : mqueue_orig::mq_send(mqdes, msg_ptr, msg_len, msg_prio);
+                                    : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_send)(mqdes, msg_ptr, msg_len, msg_prio);
 }
 
 int mq_timedsend(
     int mqdes, const char* msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec* abs_timeout)
 
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
-                                    : mqueue_orig::mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
+               : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_timedsend)(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
 }
 #endif

--- a/iceoryx_utils/testutils/mocks/time_mock.cpp
+++ b/iceoryx_utils/testutils/mocks/time_mock.cpp
@@ -19,16 +19,6 @@
 std::unique_ptr<time_MOCK> time_MOCK::mock;
 bool time_MOCK::doUseMock = false;
 
-namespace time_orig
-{
-int (*clock_getres)(clockid_t,
-                    struct timespec*) = mocks::assignSymbol<int (*)(clockid_t, struct timespec*)>("clock_getres");
-int (*clock_gettime)(clockid_t,
-                     struct timespec*) = mocks::assignSymbol<int (*)(clockid_t, struct timespec*)>("clock_gettime");
-int (*clock_settime)(clockid_t, const struct timespec*) =
-    mocks::assignSymbol<int (*)(clockid_t, const struct timespec*)>("clock_settime");
-} // namespace time_orig
-
 time_MOCK::time_MOCK()
 {
 }
@@ -39,7 +29,8 @@ int clock_getres(clockid_t clk_id, struct timespec* res)
 int clock_getres(clockid_t clk_id, struct timespec* res) noexcept
 #endif
 {
-    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_getres(clk_id, res) : time_orig::clock_getres(clk_id, res);
+    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_getres(clk_id, res)
+                                  : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(clock_getres)(clk_id, res);
 }
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
 int clock_gettime(clockid_t clk_id, struct timespec* res)
@@ -47,7 +38,8 @@ int clock_gettime(clockid_t clk_id, struct timespec* res)
 int clock_gettime(clockid_t clk_id, struct timespec* res) noexcept
 #endif
 {
-    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_gettime(clk_id, res) : time_orig::clock_gettime(clk_id, res);
+    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_gettime(clk_id, res)
+                                  : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(clock_gettime)(clk_id, res);
 }
 
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
@@ -56,6 +48,7 @@ int clock_settime(clockid_t clk_id, const struct timespec* res)
 int clock_settime(clockid_t clk_id, const struct timespec* res) noexcept
 #endif
 {
-    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_settime(clk_id, res) : time_orig::clock_settime(clk_id, res);
+    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_settime(clk_id, res)
+                                  : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(clock_settime)(clk_id, res);
 }
 #endif


### PR DESCRIPTION
Signed-off-by: Hintz Martin (CC-AD/ESW1) <martin.hintz@de.bosch.com>

## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
Adding an on demand function loader for system function mocks. This fixes #427.
To reproduce the error apply the patch file included in the bug issue to iceoryx master and run `MqMessage_test`. You can then apply the patch here and run the test successfully. Details in bug issue.

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [ ] All checkboxes in the PR checklist are checked or crossed out
1. [ ] Merge

## References

- Closes #427
