### PR TITLE
Iox #431 relative ptr invalid state ctor assigned from relative pointer

### DIFF
--- a/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
@@ -234,13 +234,13 @@ class relative_ptr : public RelativePointer
 
 
     relative_ptr(const RelativePointer& other)
+        : RelativePointer(other)
     {
-        m_offset = computeOffset(other.computeRawPtr());
     }
 
     relative_ptr& operator=(const RelativePointer& other)
     {
-        m_offset = computeOffset(other.computeRawPtr());
+        RelativePointer::operator=(other);
 
         return *this;
     }

--- a/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
@@ -253,34 +253,36 @@ class relative_ptr : public RelativePointer
         return *this;
     }
 
-    T& operator*()
+    template <typename SFINAE = T>
+    typename std::enable_if<!std::is_void<SFINAE>::value, SFINAE&>::type operator*()
     {
-        return *(static_cast<T*>(computeRawPtr()));
+        return *get();
     }
 
     T* operator->()
     {
-        return static_cast<T*>(computeRawPtr());
+        return get();
     }
 
-    const T& operator*() const
+    template <typename SFINAE = T>
+    typename std::enable_if<!std::is_void<SFINAE>::value, const SFINAE&>::type operator*() const
     {
-        return *(static_cast<T*>(computeRawPtr()));
+        return *get();
     }
 
     T* operator->() const
     {
-        return static_cast<T*>(computeRawPtr());
+        return get();
     }
 
     T* get() const
     {
-        return reinterpret_cast<T*>(RelativePointer::get());
+        return static_cast<T*>(computeRawPtr());
     }
 
     operator T*() const
     {
-        return reinterpret_cast<T*>(RelativePointer::get());
+        return get();
     }
 
     bool operator==(T* const ptr) const
@@ -289,60 +291,6 @@ class relative_ptr : public RelativePointer
     }
 
     bool operator!=(T* const ptr) const
-    {
-        return ptr != get();
-    }
-};
-
-template <>
-class relative_ptr<void> : public RelativePointer
-{
-  public:
-    relative_ptr(ptr_t ptr, id_t id)
-        : RelativePointer(ptr, id)
-    {
-    }
-
-    relative_ptr(ptr_t ptr = nullptr)
-        : RelativePointer(ptr)
-    {
-    }
-
-    relative_ptr(const RelativePointer& other)
-    {
-        m_offset = computeOffset(other.computeRawPtr());
-    }
-
-    relative_ptr& operator=(const RelativePointer& other)
-    {
-        m_offset = computeOffset(other.computeRawPtr());
-
-        return *this;
-    }
-
-    relative_ptr& operator=(ptr_t ptr)
-    {
-        m_id = searchId(ptr);
-        m_offset = computeOffset(ptr);
-        return *this;
-    }
-
-    void* get() const
-    {
-        return RelativePointer::get();
-    }
-
-    operator void*() const
-    {
-        return RelativePointer::get();
-    }
-
-    bool operator==(void* const ptr) const
-    {
-        return ptr == get();
-    }
-
-    bool operator!=(void* const ptr) const
     {
         return ptr != get();
     }

--- a/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
@@ -536,4 +536,12 @@ TEST_F(RelativePointer_test, MemoryReMapping_SharedMemory)
     }
     EXPECT_EQ(iox::RelativePointer::unregisterPtr(1), true);
 }
+
+TEST_F(RelativePointer_test, compileTest)
+{
+    // No functional test. Tests if code compiles
+    iox::relative_ptr<void> p1;
+    iox::relative_ptr<const void> p2;
+}
+
 } // namespace

--- a/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
@@ -213,6 +213,17 @@ TYPED_TEST(relativeptrtests, AssignmentOperatorTests)
     }
 
     {
+        iox::relative_ptr<TypeParam> rp;
+        rp = memMap.getMappedAddress();
+        iox::RelativePointer basePointer(rp);
+        iox::relative_ptr<TypeParam> recovered(basePointer);
+
+        EXPECT_EQ(rp, recovered);
+        EXPECT_EQ(rp.getOffset(), recovered.getOffset());
+        EXPECT_EQ(rp.getId(), recovered.getId());
+    }
+
+    {
         auto offset = ShmSize / 2;
         void* adr = static_cast<uint8_t*>(memMap.getMappedAddress()) + offset;
         iox::relative_ptr<TypeParam> rp;

--- a/iceoryx_utils/testutils/mocks/mocks.hpp
+++ b/iceoryx_utils/testutils/mocks/mocks.hpp
@@ -31,6 +31,15 @@ template <typename T>
 T assignSymbol(const std::string& functionName);
 } // namespace mocks
 
+#define STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(type, functionName)                                                       \
+    []() {                                                                                                             \
+        static auto returnValue = mocks::assignSymbol<type>(#functionName);                                            \
+        return returnValue;                                                                                            \
+    }()
+
+#define STATIC_FUNCTION_LOADER_AUTO_DEDUCE(functionName)                                                               \
+    STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(decltype(&functionName), functionName)
+
 #include "mocks.inl"
 
 #endif // IOX_UTILS_MOCKS_MOCKS_HPP

--- a/iceoryx_utils/testutils/mocks/mqueue_mock.cpp
+++ b/iceoryx_utils/testutils/mocks/mqueue_mock.cpp
@@ -21,43 +21,29 @@
 std::unique_ptr<mqueue_MOCK> mqueue_MOCK::mock;
 bool mqueue_MOCK::doUseMock = false;
 
-namespace mqueue_orig
-{
-mqd_t (*mq_open)(const char*, int, mode_t, struct mq_attr*) =
-    mocks::assignSymbol<mqd_t (*)(const char*, int, mode_t, struct mq_attr*)>("mq_open");
-mqd_t (*mq_open2)(const char*, int) = mocks::assignSymbol<mqd_t (*)(const char*, int)>("mq_open");
-int (*mq_unlink)(const char*) = mocks::assignSymbol<int (*)(const char*)>("mq_unlink");
-int (*mq_close)(int) = mocks::assignSymbol<int (*)(int)>("mq_close");
-ssize_t (*mq_receive)(int, char*, size_t, unsigned int*) =
-    mocks::assignSymbol<ssize_t (*)(int, char*, size_t, unsigned int*)>("mq_receive");
-ssize_t (*mq_timedreceive)(int, char*, size_t, unsigned int*, const struct timespec*) =
-    mocks::assignSymbol<ssize_t (*)(int, char*, size_t, unsigned int*, const struct timespec*)>("mq_timedreceive");
-int (*mq_send)(int,
-               const char*,
-               size_t,
-               unsigned int) = mocks::assignSymbol<int (*)(int, const char*, size_t, unsigned int)>("mq_send");
-int (*mq_timedsend)(int, const char*, size_t, unsigned int, const struct timespec*) =
-    mocks::assignSymbol<int (*)(int, const char*, size_t, unsigned int, const struct timespec*)>("mq_timedsend");
-} // namespace mqueue_orig
-
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
 int mq_unlink(const char* name)
 #else
 int mq_unlink(const char* name) throw()
 #endif
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_unlink(name) : mqueue_orig::mq_unlink(name);
+    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_unlink(name)
+                                    : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_unlink)(name);
 }
 
 mqd_t mq_open(const char* name, int oflag, mode_t mode, struct mq_attr* attr)
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_open(name, oflag, mode, attr)
-                                    : mqueue_orig::mq_open(name, oflag, mode, attr);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_open(name, oflag, mode, attr)
+               : STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(mqd_t(*)(const char*, int, mode_t, struct mq_attr*),
+                                                      mq_open)(name, oflag, mode, attr);
 }
 
 mqd_t mq_open(const char* name, int oflag)
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_open(name, oflag) : mqueue_orig::mq_open2(name, oflag);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_open(name, oflag)
+               : STATIC_FUNCTION_LOADER_MANUAL_DEDUCE(mqd_t(*)(const char*, int), mq_open2)(name, oflag);
 }
 
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
@@ -66,33 +52,35 @@ int mq_close(int i)
 int mq_close(int i) throw()
 #endif
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_close(i) : mqueue_orig::mq_close(i);
+    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_close(i) : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_close)(i);
 }
 
 ssize_t mq_receive(int mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio)
 {
     return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_receive(mqdes, msg_ptr, msg_len, msg_prio)
-                                    : mqueue_orig::mq_receive(mqdes, msg_ptr, msg_len, msg_prio);
+                                    : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_receive)(mqdes, msg_ptr, msg_len, msg_prio);
 }
 
 ssize_t
 mq_timedreceive(int mqdes, char* msg_ptr, size_t msg_len, unsigned int* msg_prio, const struct timespec* abs_timeout)
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
-                                    : mqueue_orig::mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_timedreceive(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
+               : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_timedreceive)(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
 }
 
 int mq_send(int mqdes, const char* msg_ptr, size_t msg_len, unsigned int msg_prio)
 {
     return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_send(mqdes, msg_ptr, msg_len, msg_prio)
-                                    : mqueue_orig::mq_send(mqdes, msg_ptr, msg_len, msg_prio);
+                                    : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_send)(mqdes, msg_ptr, msg_len, msg_prio);
 }
 
 int mq_timedsend(
     int mqdes, const char* msg_ptr, size_t msg_len, unsigned int msg_prio, const struct timespec* abs_timeout)
 
 {
-    return (mqueue_MOCK::doUseMock) ? mqueue_MOCK::mock->mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
-                                    : mqueue_orig::mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
+    return (mqueue_MOCK::doUseMock)
+               ? mqueue_MOCK::mock->mq_timedsend(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)
+               : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(mq_timedsend)(mqdes, msg_ptr, msg_len, msg_prio, abs_timeout);
 }
 #endif

--- a/iceoryx_utils/testutils/mocks/time_mock.cpp
+++ b/iceoryx_utils/testutils/mocks/time_mock.cpp
@@ -19,16 +19,6 @@
 std::unique_ptr<time_MOCK> time_MOCK::mock;
 bool time_MOCK::doUseMock = false;
 
-namespace time_orig
-{
-int (*clock_getres)(clockid_t,
-                    struct timespec*) = mocks::assignSymbol<int (*)(clockid_t, struct timespec*)>("clock_getres");
-int (*clock_gettime)(clockid_t,
-                     struct timespec*) = mocks::assignSymbol<int (*)(clockid_t, struct timespec*)>("clock_gettime");
-int (*clock_settime)(clockid_t, const struct timespec*) =
-    mocks::assignSymbol<int (*)(clockid_t, const struct timespec*)>("clock_settime");
-} // namespace time_orig
-
 time_MOCK::time_MOCK()
 {
 }
@@ -39,7 +29,8 @@ int clock_getres(clockid_t clk_id, struct timespec* res)
 int clock_getres(clockid_t clk_id, struct timespec* res) noexcept
 #endif
 {
-    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_getres(clk_id, res) : time_orig::clock_getres(clk_id, res);
+    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_getres(clk_id, res)
+                                  : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(clock_getres)(clk_id, res);
 }
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
 int clock_gettime(clockid_t clk_id, struct timespec* res)
@@ -47,7 +38,8 @@ int clock_gettime(clockid_t clk_id, struct timespec* res)
 int clock_gettime(clockid_t clk_id, struct timespec* res) noexcept
 #endif
 {
-    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_gettime(clk_id, res) : time_orig::clock_gettime(clk_id, res);
+    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_gettime(clk_id, res)
+                                  : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(clock_gettime)(clk_id, res);
 }
 
 #if defined(QNX) || defined(QNX__) || defined(__QNX__)
@@ -56,6 +48,7 @@ int clock_settime(clockid_t clk_id, const struct timespec* res)
 int clock_settime(clockid_t clk_id, const struct timespec* res) noexcept
 #endif
 {
-    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_settime(clk_id, res) : time_orig::clock_settime(clk_id, res);
+    return (time_MOCK::doUseMock) ? time_MOCK::mock->clock_settime(clk_id, res)
+                                  : STATIC_FUNCTION_LOADER_AUTO_DEDUCE(clock_settime)(clk_id, res);
 }
 #endif


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [ ] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [ ] Commits messages are according to this [guideline][commit-guidelines]
    - [ ] Commit messages have the issue ID (`iox-#123 commit text`)
    - [ ] Commit messages are signed (`git commit -s`)
    - [ ] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [ ] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [ ] Relevant issues are linked
1. [ ] Add sensible notes for the reviewer
1. [ ] All checks have passed
1. [ ] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
1. Fix 1: Base c'tor/ operator `=` is called instead of `computeOffset(`. This fixes #431.
1. Fix 2: `const void` was not supported as type. Removed the specialized template and using a SFINAE approach now. Added a test for this as well.
3. I don't like the naming. Why is the typed version of `iox::RelativePointer` called `iox::relative_ptr` ? I'd like to change it to `iox::TypedRelativePointer`. Thoughts?

## Checklist for the PR Reviewer

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] Code according to our coding style and naming conventions
- [ ] Unit tests have been written for new behavior
- [ ] Public API changes are documented via doxygen
- [ ] Copyright owner are updated in the changed files
- [ ] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [ ] All checkboxes in the PR checklist are checked or crossed out
1. [ ] Merge

## References

- Closes #431