### PR TITLE
Iox #431 iox::relative_ptr takes invalid state when constructed/assigned from iox::RelativePointer

### DIFF
--- a/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
@@ -234,13 +234,13 @@ class relative_ptr : public RelativePointer
 
 
     relative_ptr(const RelativePointer& other)
+        : RelativePointer(other)
     {
-        m_offset = computeOffset(other.computeRawPtr());
     }
 
     relative_ptr& operator=(const RelativePointer& other)
     {
-        m_offset = computeOffset(other.computeRawPtr());
+        RelativePointer::operator=(other);
 
         return *this;
     }

--- a/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
@@ -253,34 +253,36 @@ class relative_ptr : public RelativePointer
         return *this;
     }
 
-    T& operator*()
+    template <typename SFINAE = T>
+    typename std::enable_if<!std::is_void<SFINAE>::value, SFINAE&>::type operator*()
     {
-        return *(static_cast<T*>(computeRawPtr()));
+        return *get();
     }
 
     T* operator->()
     {
-        return static_cast<T*>(computeRawPtr());
+        return get();
     }
 
-    const T& operator*() const
+    template <typename SFINAE = T>
+    typename std::enable_if<!std::is_void<SFINAE>::value, const SFINAE&>::type operator*() const
     {
-        return *(static_cast<T*>(computeRawPtr()));
+        return *get();
     }
 
     T* operator->() const
     {
-        return static_cast<T*>(computeRawPtr());
+        return get();
     }
 
     T* get() const
     {
-        return reinterpret_cast<T*>(RelativePointer::get());
+        return static_cast<T*>(computeRawPtr());
     }
 
     operator T*() const
     {
-        return reinterpret_cast<T*>(RelativePointer::get());
+        return get();
     }
 
     bool operator==(T* const ptr) const
@@ -289,60 +291,6 @@ class relative_ptr : public RelativePointer
     }
 
     bool operator!=(T* const ptr) const
-    {
-        return ptr != get();
-    }
-};
-
-template <>
-class relative_ptr<void> : public RelativePointer
-{
-  public:
-    relative_ptr(ptr_t ptr, id_t id)
-        : RelativePointer(ptr, id)
-    {
-    }
-
-    relative_ptr(ptr_t ptr = nullptr)
-        : RelativePointer(ptr)
-    {
-    }
-
-    relative_ptr(const RelativePointer& other)
-    {
-        m_offset = computeOffset(other.computeRawPtr());
-    }
-
-    relative_ptr& operator=(const RelativePointer& other)
-    {
-        m_offset = computeOffset(other.computeRawPtr());
-
-        return *this;
-    }
-
-    relative_ptr& operator=(ptr_t ptr)
-    {
-        m_id = searchId(ptr);
-        m_offset = computeOffset(ptr);
-        return *this;
-    }
-
-    void* get() const
-    {
-        return RelativePointer::get();
-    }
-
-    operator void*() const
-    {
-        return RelativePointer::get();
-    }
-
-    bool operator==(void* const ptr) const
-    {
-        return ptr == get();
-    }
-
-    bool operator!=(void* const ptr) const
     {
         return ptr != get();
     }

--- a/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
@@ -240,7 +240,7 @@ class relative_ptr : public RelativePointer
 
     relative_ptr& operator=(const RelativePointer& other)
     {
-        RelativePointer::operator=(other);
+        *this = other;
 
         return *this;
     }
@@ -253,8 +253,8 @@ class relative_ptr : public RelativePointer
         return *this;
     }
 
-    template <typename SFINAE = T>
-    typename std::enable_if<!std::is_void<SFINAE>::value, SFINAE&>::type operator*()
+    template <typename U = T>
+    typename std::enable_if<!std::is_void<U>::value, U&>::type operator*()
     {
         return *get();
     }
@@ -264,8 +264,8 @@ class relative_ptr : public RelativePointer
         return get();
     }
 
-    template <typename SFINAE = T>
-    typename std::enable_if<!std::is_void<SFINAE>::value, const SFINAE&>::type operator*() const
+    template <typename U = T>
+    typename std::enable_if<!std::is_void<U>::value, const U&>::type operator*() const
     {
         return *get();
     }

--- a/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
+++ b/iceoryx_utils/include/iceoryx_utils/internal/relocatable_pointer/relative_ptr.hpp
@@ -240,7 +240,7 @@ class relative_ptr : public RelativePointer
 
     relative_ptr& operator=(const RelativePointer& other)
     {
-        *this = other;
+        RelativePointer::operator=(other);
 
         return *this;
     }

--- a/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
@@ -536,4 +536,12 @@ TEST_F(RelativePointer_test, MemoryReMapping_SharedMemory)
     }
     EXPECT_EQ(iox::RelativePointer::unregisterPtr(1), true);
 }
+
+TEST_F(RelativePointer_test, compileTest)
+{
+    // No functional test. Tests if code compiles
+    iox::relative_ptr<void> p1;
+    iox::relative_ptr<const void> p2;
+}
+
 } // namespace

--- a/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
@@ -221,6 +221,11 @@ TYPED_TEST(relativeptrtests, AssignmentOperatorTests)
         EXPECT_EQ(rp, recovered);
         EXPECT_EQ(rp.getOffset(), recovered.getOffset());
         EXPECT_EQ(rp.getId(), recovered.getId());
+
+        recovered = basePointer;
+        EXPECT_EQ(rp, recovered);
+        EXPECT_EQ(rp.getOffset(), recovered.getOffset());
+        EXPECT_EQ(rp.getId(), recovered.getId());
     }
 
     {

--- a/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
+++ b/iceoryx_utils/test/moduletests/test_relative_pointer.cpp
@@ -213,6 +213,17 @@ TYPED_TEST(relativeptrtests, AssignmentOperatorTests)
     }
 
     {
+        iox::relative_ptr<TypeParam> rp;
+        rp = memMap.getMappedAddress();
+        iox::RelativePointer basePointer(rp);
+        iox::relative_ptr<TypeParam> recovered(basePointer);
+
+        EXPECT_EQ(rp, recovered);
+        EXPECT_EQ(rp.getOffset(), recovered.getOffset());
+        EXPECT_EQ(rp.getId(), recovered.getId());
+    }
+
+    {
         auto offset = ShmSize / 2;
         void* adr = static_cast<uint8_t*>(memMap.getMappedAddress()) + offset;
         iox::relative_ptr<TypeParam> rp;


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
1. Fix 1: Base c'tor/ operator `=` is called instead of `computeOffset()`. This fixes #431.
1. Fix 2: `const void` was not supported as type. Removed the specialized template and using a SFINAE approach now. Added a test for this as well.
3. I don't like the naming. Why is the typed version of `iox::RelativePointer` called `iox::relative_ptr` ? I'd like to change it to `iox::TypedRelativePointer`. Thoughts?

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [ ] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [ ] All checkboxes in the PR checklist are checked or crossed out
1. [ ] Merge

## References

- Closes #431