### PR TITLE
Iox #408 add struct with options to subscriber

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,7 @@ See [error-handling.md](./doc/error-handling.md) for additional information abou
 * Methods and variables in `lowerCamelCase`: `uint16_t myVariable`
 * Compile time constants, also enum values in `UPPER_SNAKE_CASE`: `static constexpr uint16_t MY_CONSTANT`
 * Class members start with `m_`: `m_myMember`
+    * Public members of structs and classes do not have the `m_` prefix
 * Namespaces in `lower_snake_case` : `my_namespace`
 * Aliases have a `_t` postfix : `using FooString_t = iox::cxx::string<100>;`
 

--- a/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
@@ -27,13 +27,15 @@ typedef struct cpp2c_Subscriber* iox_sub_t;
 /// @param[in] service serviceString
 /// @param[in] instance instanceString
 /// @param[in] event eventString
-/// @param[in] historyCapacity size of the history chunk queue
+/// @param[in] queueCapacity size of the receiver queue
+/// @param[in] historyCapacity max number of chunks  received as history after subscription
 /// @return handle of the subscriber
 iox_sub_t iox_sub_init(iox_sub_storage_t* self,
                        const char* const service,
                        const char* const instance,
                        const char* const event,
-                       uint64_t historyRequest);
+                       const uint64_t queueCapacity,
+                       const uint64_t historyRequest);
 
 /// @brief deinitialize a subscriber handle
 /// @param[in] self the handle which should be removed

--- a/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
@@ -43,8 +43,7 @@ void iox_sub_deinit(iox_sub_t const self);
 
 /// @brief subscribes to the service
 /// @param[in] self handle to the subscriber
-/// @param[in] queueCapacity size of the receiver queue
-void iox_sub_subscribe(iox_sub_t const self, const uint64_t queueCapacity);
+void iox_sub_subscribe(iox_sub_t const self);
 
 /// @brief unsubscribes from a service
 /// @param[in] self handle to the subscriber

--- a/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
+++ b/iceoryx_binding_c/include/iceoryx_binding_c/subscriber.h
@@ -28,7 +28,7 @@ typedef struct cpp2c_Subscriber* iox_sub_t;
 /// @param[in] instance instanceString
 /// @param[in] event eventString
 /// @param[in] queueCapacity size of the receiver queue
-/// @param[in] historyCapacity max number of chunks  received as history after subscription
+/// @param[in] historyRequest of chunks received after subscription if chunks are available
 /// @return handle of the subscriber
 iox_sub_t iox_sub_init(iox_sub_storage_t* self,
                        const char* const service,

--- a/iceoryx_binding_c/source/c_publisher.cpp
+++ b/iceoryx_binding_c/source/c_publisher.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,13 +36,15 @@ iox_pub_t iox_pub_init(iox_pub_storage_t* self,
 {
     new (self) cpp2c_Publisher();
     iox_pub_t me = reinterpret_cast<iox_pub_t>(self);
+    iox::popo::PublisherOptions options;
+    options.historyCapacity = historyCapacity;
     me->m_portData = PoshRuntime::getInstance().getMiddlewarePublisher(
         ServiceDescription{
             IdString_t(TruncateToCapacity, service),
             IdString_t(TruncateToCapacity, instance),
             IdString_t(TruncateToCapacity, event),
         },
-        historyCapacity);
+        options);
     return me;
 }
 

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -59,9 +59,9 @@ void iox_sub_deinit(iox_sub_t const self)
     self->~cpp2c_Subscriber();
 }
 
-void iox_sub_subscribe(iox_sub_t const self, const uint64_t queueCapacity)
+void iox_sub_subscribe(iox_sub_t const self)
 {
-    SubscriberPortUser(self->m_portData).subscribe(queueCapacity);
+    SubscriberPortUser(self->m_portData).subscribe();
 }
 
 void iox_sub_unsubscribe(iox_sub_t const self)

--- a/iceoryx_binding_c/source/c_subscriber.cpp
+++ b/iceoryx_binding_c/source/c_subscriber.cpp
@@ -37,15 +37,19 @@ iox_sub_t iox_sub_init(iox_sub_storage_t* self,
                        const char* const service,
                        const char* const instance,
                        const char* const event,
-                       uint64_t historyRequest)
+                       const uint64_t queueCapacity,
+                       const uint64_t historyRequest)
 {
     new (self) cpp2c_Subscriber();
     iox_sub_t me = reinterpret_cast<iox_sub_t>(self);
+    SubscriberOptions options;
+    options.queueCapacity = queueCapacity;
+    options.historyRequest = historyRequest;
     me->m_portData =
         PoshRuntime::getInstance().getMiddlewareSubscriber(ServiceDescription{IdString_t(TruncateToCapacity, service),
                                                                               IdString_t(TruncateToCapacity, instance),
                                                                               IdString_t(TruncateToCapacity, event)},
-                                                           historyRequest);
+                                                           options);
 
     return me;
 }

--- a/iceoryx_binding_c/test/moduletests/test_event_info.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_event_info.cpp
@@ -61,8 +61,7 @@ class iox_event_info_test : public Test
 
     void Subscribe(SubscriberPortData* ptr)
     {
-        uint64_t queueCapacity = MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY;
-        iox_sub_subscribe(m_subscriberHandle, queueCapacity);
+        iox_sub_subscribe(m_subscriberHandle);
 
         SubscriberPortSingleProducer(ptr).tryGetCaProMessage();
         iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK, TEST_SERVICE_DESCRIPTION);
@@ -87,8 +86,11 @@ class iox_event_info_test : public Test
     Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     MePooConfig m_mempoolconf;
     MemoryManager m_memoryManager;
-    iox::popo::SubscriberPortData m_portPtr{
-        TEST_SERVICE_DESCRIPTION, "myApp", iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+    SubscriberOptions m_subscriberOPtions{MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, 0U};
+    iox::popo::SubscriberPortData m_portPtr{TEST_SERVICE_DESCRIPTION,
+                                            "myApp",
+                                            iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                            m_subscriberOPtions};
     ChunkQueuePusher<SubscriberPortData::ChunkQueueData_t> m_chunkPusher{&m_portPtr.m_chunkReceiverData};
     cpp2c_Subscriber m_subscriber;
     iox_sub_t m_subscriberHandle = &m_subscriber;
@@ -231,4 +233,3 @@ TEST_F(iox_event_info_test, callbackCanBeCalledMultipleTimes)
 
     EXPECT_EQ(m_lastEventCallbackArgument, &m_userTrigger);
 }
-

--- a/iceoryx_binding_c/test/moduletests/test_publisher.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_publisher.cpp
@@ -104,7 +104,8 @@ class iox_pub_test : public Test
     MemoryManager m_memoryManager;
 
     // publisher port w/o history
-    PublisherPortData m_publisherPortData{ServiceDescription("a", "b", "c"), "myApp", &m_memoryManager};
+    PublisherPortData m_publisherPortData{
+        ServiceDescription("a", "b", "c"), "myApp", &m_memoryManager, PublisherOptions()};
 
     // publisher port w/ history
     PublisherOptions m_publisherOptions{MAX_PUBLISHER_HISTORY};
@@ -231,3 +232,4 @@ TEST_F(iox_pub_test, sendDeliversChunk)
     EXPECT_TRUE(*maybeSharedChunk == chunk);
     EXPECT_TRUE(static_cast<DummySample*>(maybeSharedChunk->getPayload())->dummy == 4711);
 }
+

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -62,7 +62,6 @@ class iox_sub_test : public Test
 
     void Subscribe(SubscriberPortData* ptr)
     {
-        uint64_t queueCapacity = MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY;
         iox_sub_subscribe(m_sut);
 
         SubscriberPortSingleProducer(ptr).tryGetCaProMessage();
@@ -87,10 +86,11 @@ class iox_sub_test : public Test
 
     iox::cxx::GenericRAII m_uniqueRouDiId{[] { iox::popo::internal::setUniqueRouDiId(0); },
                                           [] { iox::popo::internal::unsetUniqueRouDiId(); }};
+    iox::popo::SubscriberOptions subscriberOptions{MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY, 0U};
     iox::popo::SubscriberPortData m_portPtr{TEST_SERVICE_DESCRIPTION,
                                             "myApp",
                                             iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
-                                            iox::popo::SubscriberOptions{1U, 0U}};
+                                            subscriberOptions};
     ChunkQueuePusher<SubscriberPortData::ChunkQueueData_t> m_chunkPusher{&m_portPtr.m_chunkReceiverData};
     std::unique_ptr<cpp2c_Subscriber> m_subscriber{new cpp2c_Subscriber};
     iox_sub_t m_sut = m_subscriber.get();

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -63,7 +63,7 @@ class iox_sub_test : public Test
     void Subscribe(SubscriberPortData* ptr)
     {
         uint64_t queueCapacity = MAX_CHUNKS_HELD_PER_SUBSCRIBER_SIMULTANEOUSLY;
-        iox_sub_subscribe(m_sut, queueCapacity);
+        iox_sub_subscribe(m_sut);
 
         SubscriberPortSingleProducer(ptr).tryGetCaProMessage();
         iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK, TEST_SERVICE_DESCRIPTION);
@@ -87,8 +87,10 @@ class iox_sub_test : public Test
 
     iox::cxx::GenericRAII m_uniqueRouDiId{[] { iox::popo::internal::setUniqueRouDiId(0); },
                                           [] { iox::popo::internal::unsetUniqueRouDiId(); }};
-    iox::popo::SubscriberPortData m_portPtr{
-        TEST_SERVICE_DESCRIPTION, "myApp", iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+    iox::popo::SubscriberPortData m_portPtr{TEST_SERVICE_DESCRIPTION,
+                                            "myApp",
+                                            iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                            iox::popo::SubscriberOptions()};
     ChunkQueuePusher<SubscriberPortData::ChunkQueueData_t> m_chunkPusher{&m_portPtr.m_chunkReceiverData};
     std::unique_ptr<cpp2c_Subscriber> m_subscriber{new cpp2c_Subscriber};
     iox_sub_t m_sut = m_subscriber.get();
@@ -107,7 +109,7 @@ TEST_F(iox_sub_test, initialStateNotSubscribed)
 TEST_F(iox_sub_test, offerLeadsToSubscibeRequestedState)
 {
     uint64_t queueCapacity = 1U;
-    iox_sub_subscribe(m_sut, queueCapacity);
+    iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
 
@@ -117,7 +119,7 @@ TEST_F(iox_sub_test, offerLeadsToSubscibeRequestedState)
 TEST_F(iox_sub_test, NACKResponseLeadsToSubscribeWaitForOfferState)
 {
     uint64_t queueCapacity = 1U;
-    iox_sub_subscribe(m_sut, queueCapacity);
+    iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::NACK, TEST_SERVICE_DESCRIPTION);
@@ -129,7 +131,7 @@ TEST_F(iox_sub_test, NACKResponseLeadsToSubscribeWaitForOfferState)
 TEST_F(iox_sub_test, ACKResponseLeadsToSubscribedState)
 {
     uint64_t queueCapacity = 1U;
-    iox_sub_subscribe(m_sut, queueCapacity);
+    iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK, TEST_SERVICE_DESCRIPTION);
@@ -141,7 +143,7 @@ TEST_F(iox_sub_test, ACKResponseLeadsToSubscribedState)
 TEST_F(iox_sub_test, UnsubscribeLeadsToUnscribeRequestedState)
 {
     uint64_t queueCapacity = 1U;
-    iox_sub_subscribe(m_sut, queueCapacity);
+    iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
     iox::capro::CaproMessage caproMessage(iox::capro::CaproMessageType::ACK, TEST_SERVICE_DESCRIPTION);

--- a/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
+++ b/iceoryx_binding_c/test/moduletests/test_subscriber.cpp
@@ -90,7 +90,7 @@ class iox_sub_test : public Test
     iox::popo::SubscriberPortData m_portPtr{TEST_SERVICE_DESCRIPTION,
                                             "myApp",
                                             iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
-                                            iox::popo::SubscriberOptions()};
+                                            iox::popo::SubscriberOptions{1U, 0U}};
     ChunkQueuePusher<SubscriberPortData::ChunkQueueData_t> m_chunkPusher{&m_portPtr.m_chunkReceiverData};
     std::unique_ptr<cpp2c_Subscriber> m_subscriber{new cpp2c_Subscriber};
     iox_sub_t m_sut = m_subscriber.get();
@@ -108,7 +108,6 @@ TEST_F(iox_sub_test, initialStateNotSubscribed)
 
 TEST_F(iox_sub_test, offerLeadsToSubscibeRequestedState)
 {
-    uint64_t queueCapacity = 1U;
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -118,7 +117,6 @@ TEST_F(iox_sub_test, offerLeadsToSubscibeRequestedState)
 
 TEST_F(iox_sub_test, NACKResponseLeadsToSubscribeWaitForOfferState)
 {
-    uint64_t queueCapacity = 1U;
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -130,7 +128,6 @@ TEST_F(iox_sub_test, NACKResponseLeadsToSubscribeWaitForOfferState)
 
 TEST_F(iox_sub_test, ACKResponseLeadsToSubscribedState)
 {
-    uint64_t queueCapacity = 1U;
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();
@@ -142,7 +139,6 @@ TEST_F(iox_sub_test, ACKResponseLeadsToSubscribedState)
 
 TEST_F(iox_sub_test, UnsubscribeLeadsToUnscribeRequestedState)
 {
-    uint64_t queueCapacity = 1U;
     iox_sub_subscribe(m_sut);
 
     SubscriberPortSingleProducer(&m_portPtr).tryGetCaProMessage();

--- a/iceoryx_dds/include/iceoryx_dds/gateway/dds_to_iox.hpp
+++ b/iceoryx_dds/include/iceoryx_dds/gateway/dds_to_iox.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ class DDS2IceoryxGateway : public gateway_t
 
   private:
     void* m_reservedChunk = nullptr;
-    cxx::expected<channel_t, gw::GatewayError> setupChannel(const capro::ServiceDescription& service) noexcept;
+    cxx::expected<channel_t, gw::GatewayError> setupChannel(const capro::ServiceDescription& service,
+                                                            const popo::PublisherOptions& publisherOptions) noexcept;
 };
 
 } // namespace dds

--- a/iceoryx_dds/include/iceoryx_dds/gateway/iox_to_dds.hpp
+++ b/iceoryx_dds/include/iceoryx_dds/gateway/iox_to_dds.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,7 +38,8 @@ class Iceoryx2DDSGateway : public gateway_t
     void forward(const channel_t& channel) noexcept;
 
   private:
-    cxx::expected<channel_t, gw::GatewayError> setupChannel(const capro::ServiceDescription& service) noexcept;
+    cxx::expected<channel_t, gw::GatewayError> setupChannel(const capro::ServiceDescription& service,
+                                                            const popo::SubscriberOptions&) noexcept;
 };
 
 } // namespace dds

--- a/iceoryx_dds/include/iceoryx_dds/internal/gateway/dds_to_iox.inl
+++ b/iceoryx_dds/include/iceoryx_dds/internal/gateway/dds_to_iox.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ inline void DDS2IceoryxGateway<channel_t, gateway_t>::loadConfiguration(const co
             LogDebug() << "[DDS2IceoryxGateway] Setting up channel for service: {"
                        << serviceDescription.getServiceIDString() << ", " << serviceDescription.getInstanceIDString()
                        << ", " << serviceDescription.getEventIDString() << "}";
-            setupChannel(serviceDescription);
+            setupChannel(serviceDescription, popo::PublisherOptions());
         }
     }
 }
@@ -77,9 +77,10 @@ inline void DDS2IceoryxGateway<channel_t, gateway_t>::forward(const channel_t& c
 // ======================================== Private ======================================== //
 template <typename channel_t, typename gateway_t>
 cxx::expected<channel_t, gw::GatewayError>
-DDS2IceoryxGateway<channel_t, gateway_t>::setupChannel(const capro::ServiceDescription& service) noexcept
+DDS2IceoryxGateway<channel_t, gateway_t>::setupChannel(const capro::ServiceDescription& service,
+                                                       const popo::PublisherOptions& publisherOptions) noexcept
 {
-    return this->addChannel(service).and_then([&service](auto channel) {
+    return this->addChannel(service, publisherOptions).and_then([&service](auto channel) {
         auto publisher = channel.getIceoryxTerminal();
         auto reader = channel.getExternalTerminal();
         publisher->offer();

--- a/iceoryx_dds/test/helpers/fixture_dds_gateway.hpp
+++ b/iceoryx_dds/test/helpers/fixture_dds_gateway.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -55,9 +55,11 @@ class DDSGatewayTestFixture : public Test
         m_stagedMockDDSTerminal.emplace_back(std::move(mock));
     };
     // Create a new iceoryx mock
-    std::shared_ptr<IceoryxTerminal> createMockIceoryxTerminal(const iox::capro::ServiceDescription& sd)
+    template <typename IceoryxPubSubOptions>
+    std::shared_ptr<IceoryxTerminal> createMockIceoryxTerminal(const iox::capro::ServiceDescription& sd,
+                                                               const IceoryxPubSubOptions& options)
     {
-        return std::shared_ptr<IceoryxTerminal>(new IceoryxTerminal(sd));
+        return std::shared_ptr<IceoryxTerminal>(new IceoryxTerminal(sd, options));
     }
     // Stage the given mock to be used in the channel factory
     void stageMockIceoryxTerminal(std::shared_ptr<IceoryxTerminal>&& mock)
@@ -68,8 +70,9 @@ class DDSGatewayTestFixture : public Test
     // Creates channels to be used in tests.
     // Channels will contain staged mocks, or empty mocks if none are staged.
     // The factory method can be passed to test gateways, allowing injection of mocks.
+    template <typename IceoryxPubSubOptions>
     iox::cxx::expected<iox::gw::Channel<IceoryxTerminal, DDSTerminal>, iox::gw::GatewayError>
-    channelFactory(iox::capro::ServiceDescription sd) noexcept
+    channelFactory(iox::capro::ServiceDescription sd, const IceoryxPubSubOptions& options) noexcept
     {
         // Get or create a mock iceoryx terminal
         std::shared_ptr<IceoryxTerminal> mockIceoryxTerminal;
@@ -80,7 +83,7 @@ class DDSGatewayTestFixture : public Test
         }
         else
         {
-            mockIceoryxTerminal = createMockIceoryxTerminal(sd);
+            mockIceoryxTerminal = createMockIceoryxTerminal(sd, options);
         }
 
         // Get or create a mock dds terminal

--- a/iceoryx_dds/test/mocks/google_mocks.hpp
+++ b/iceoryx_dds/test/mocks/google_mocks.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,8 @@
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
 #include "iceoryx_posh/popo/base_publisher.hpp"
 #include "iceoryx_posh/popo/base_subscriber.hpp"
+#include "iceoryx_posh/popo/publisher_options.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/expected.hpp"
 #include "iceoryx_utils/cxx/function_ref.hpp"
 #include "iceoryx_utils/cxx/optional.hpp"
@@ -34,7 +36,7 @@ template <typename T>
 class MockPublisher : public iox::popo::PublisherInterface<T>
 {
   public:
-    MockPublisher(const iox::capro::ServiceDescription&){};
+    MockPublisher(const iox::capro::ServiceDescription&, const iox::popo::PublisherOptions&){};
     virtual ~MockPublisher() = default;
     MOCK_CONST_METHOD0(getUid, iox::popo::uid_t());
     MOCK_METHOD1_T(loan, iox::cxx::expected<iox::popo::Sample<T>, iox::popo::AllocationError>(uint32_t));
@@ -54,10 +56,10 @@ template <typename T>
 class MockSubscriber
 {
   public:
-    MockSubscriber(const iox::capro::ServiceDescription&){};
+    MockSubscriber(const iox::capro::ServiceDescription&, const iox::popo::SubscriberOptions&){};
     MOCK_CONST_METHOD0(getUid, iox::popo::uid_t());
     MOCK_CONST_METHOD0(getServiceDescription, iox::capro::ServiceDescription());
-    MOCK_METHOD1(subscribe, void(uint64_t));
+    MOCK_METHOD0(subscribe, void());
     MOCK_CONST_METHOD0(getSubscriptionState, iox::SubscribeState());
     MOCK_METHOD0(unsubscribe, void());
     MOCK_CONST_METHOD0(hasSamples, bool());
@@ -97,15 +99,16 @@ class MockDataWriter
     MOCK_CONST_METHOD0(getEventId, std::string(void));
 };
 
-template <typename channel_t>
+template <typename channel_t, typename IceoryxPubSubOptions>
 class MockGenericGateway
 {
   public:
     MockGenericGateway(){};
     MockGenericGateway(const iox::capro::Interfaces, iox::units::Duration, iox::units::Duration){};
     MOCK_METHOD1(getCaProMessage, bool(iox::capro::CaproMessage&));
-    MOCK_METHOD1_T(addChannel,
-                   iox::cxx::expected<channel_t, iox::gw::GatewayError>(const iox::capro::ServiceDescription&));
+    MOCK_METHOD2_T(addChannel,
+                   iox::cxx::expected<channel_t, iox::gw::GatewayError>(const iox::capro::ServiceDescription&,
+                                                                        const IceoryxPubSubOptions&));
     MOCK_METHOD1(discardChannel, iox::cxx::expected<iox::gw::GatewayError>(const iox::capro::ServiceDescription&));
     MOCK_METHOD1_T(findChannel, iox::cxx::optional<channel_t>(const iox::capro::ServiceDescription&));
     MOCK_METHOD1_T(forEachChannel, void(const iox::cxx::function_ref<void(channel_t&)>));

--- a/iceoryx_examples/ice_multi_publisher/ice_resubscriber.cpp
+++ b/iceoryx_examples/ice_multi_publisher/ice_resubscriber.cpp
@@ -27,16 +27,14 @@ static void sigHandler(int sig [[gnu::unused]])
     killswitch = true;
 }
 
-// the maximum number of samples the subscriber can hold before discarding the least
-// recent sample (i.e. the capacity of the sample queue on subscriber side)
-constexpr uint64_t MAX_NUMBER_OF_SAMPLES{4U};
-
 constexpr uint64_t UNSUBSCRIBED_TIME_SECONDS{3U};
 
 void receive()
 {
     iox::popo::SubscriberOptions options;
-    options.queueCapacity = MAX_NUMBER_OF_SAMPLES - 2U;
+    // the maximum number of samples the subscriber can hold before discarding the least
+    // recent sample (i.e. the capacity of the sample queue on subscriber side)
+    options.queueCapacity = 4U;
     iox::popo::TypedSubscriber<CounterTopic> subscriber({"Group", "Instance", "Counter"}, options);
 
     subscriber.subscribe();

--- a/iceoryx_examples/ice_multi_publisher/ice_resubscriber.cpp
+++ b/iceoryx_examples/ice_multi_publisher/ice_resubscriber.cpp
@@ -35,10 +35,11 @@ constexpr uint64_t UNSUBSCRIBED_TIME_SECONDS{3U};
 
 void receive()
 {
-    iox::popo::TypedSubscriber<CounterTopic> subscriber({"Group", "Instance", "Counter"});
+    iox::popo::SubscriberOptions options;
+    options.queueCapacity = MAX_NUMBER_OF_SAMPLES - 2U;
+    iox::popo::TypedSubscriber<CounterTopic> subscriber({"Group", "Instance", "Counter"}, options);
 
     subscriber.subscribe();
-    uint64_t maxNumSamples = MAX_NUMBER_OF_SAMPLES - 2U;
     while (!killswitch)
     {
         // unsubscribe and resubscribe
@@ -48,13 +49,8 @@ void receive()
         // we will probably miss some data while unsubscribed
         std::this_thread::sleep_for(std::chrono::seconds(UNSUBSCRIBED_TIME_SECONDS));
 
-        // we (re)subscribe with differing maximum number of samples
-        // and should see at most the latest last maxNumSamples
-        maxNumSamples =
-            maxNumSamples % MAX_NUMBER_OF_SAMPLES + 1U; // cycles between last 1 to MAX_NUMBER_OF_SAMPLES samples
-        subscriber.subscribe(maxNumSamples);
-
-        std::cout << "Subscribe with max number of samples " << maxNumSamples << std::endl;
+        // we (re)subscribe and should see at most the latest options.queueCapacity
+        subscriber.subscribe();
 
         std::this_thread::sleep_for(std::chrono::seconds(1));
 

--- a/iceoryx_examples/icedelivery_on_c/ice_c_subscriber.c
+++ b/iceoryx_examples/icedelivery_on_c/ice_c_subscriber.c
@@ -41,7 +41,7 @@ void receiving()
 
     iox_sub_t subscriber =
         iox_sub_init(&subscriberStorage, "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
-    iox_sub_subscribe(subscriber, queueCapacity);
+    iox_sub_subscribe(subscriber);
 
     while (!killswitch)
     {

--- a/iceoryx_examples/icedelivery_on_c/ice_c_subscriber.c
+++ b/iceoryx_examples/icedelivery_on_c/ice_c_subscriber.c
@@ -35,11 +35,13 @@ void receiving()
 {
     iox_runtime_init("iox-c-subscriber");
 
-    uint64_t historyRequest = 0U;
+    const uint64_t historyRequest = 0U;
+    const uint64_t queueCapacity = 10U;
     iox_sub_storage_t subscriberStorage;
 
-    iox_sub_t subscriber = iox_sub_init(&subscriberStorage, "Radar", "FrontLeft", "Counter", historyRequest);
-    iox_sub_subscribe(subscriber, 10);
+    iox_sub_t subscriber =
+        iox_sub_init(&subscriberStorage, "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
+    iox_sub_subscribe(subscriber, queueCapacity);
 
     while (!killswitch)
     {

--- a/iceoryx_examples/singleprocess/single_process.cpp
+++ b/iceoryx_examples/singleprocess/single_process.cpp
@@ -62,10 +62,11 @@ void sender()
 
 void receiver()
 {
-    iox::popo::TypedSubscriber<TransmissionData_t> subscriber({"Single", "Process", "Demo"});
+    iox::popo::SubscriberOptions options;
+    options.queueCapacity = 10U;
+    iox::popo::TypedSubscriber<TransmissionData_t> subscriber({"Single", "Process", "Demo"}, options);
 
-    uint64_t cacheQueueSize = 10;
-    subscriber.subscribe(cacheQueueSize);
+    subscriber.subscribe();
 
     while (keepRunning.load())
     {

--- a/iceoryx_examples/waitset_on_c/ice_c_waitset_gateway.c
+++ b/iceoryx_examples/waitset_on_c/ice_c_waitset_gateway.c
@@ -71,12 +71,14 @@ int main()
     iox_sub_storage_t subscriberStorage[NUMBER_OF_SUBSCRIBERS];
 
     // create subscriber and subscribe them to our service
-    uint64_t historyRequest = 1U;
+    const uint64_t historyRequest = 1U;
+    const uint64_t queueCapacity = 256U;
     for (uint64_t i = 0U; i < NUMBER_OF_SUBSCRIBERS; ++i)
     {
-        iox_sub_t subscriber = iox_sub_init(&(subscriberStorage[i]), "Radar", "FrontLeft", "Counter", historyRequest);
+        iox_sub_t subscriber =
+            iox_sub_init(&(subscriberStorage[i]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
 
-        iox_sub_subscribe(subscriber, 256);
+        iox_sub_subscribe(subscriber, queueCapacity);
         iox_ws_attach_subscriber_event(waitSet, subscriber, SubscriberEvent_HAS_SAMPLES, 1U, subscriberCallback);
     }
 

--- a/iceoryx_examples/waitset_on_c/ice_c_waitset_gateway.c
+++ b/iceoryx_examples/waitset_on_c/ice_c_waitset_gateway.c
@@ -78,7 +78,7 @@ int main()
         iox_sub_t subscriber =
             iox_sub_init(&(subscriberStorage[i]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
 
-        iox_sub_subscribe(subscriber, queueCapacity);
+        iox_sub_subscribe(subscriber);
         iox_ws_attach_subscriber_event(waitSet, subscriber, SubscriberEvent_HAS_SAMPLES, 1U, subscriberCallback);
     }
 

--- a/iceoryx_examples/waitset_on_c/ice_c_waitset_grouping.c
+++ b/iceoryx_examples/waitset_on_c/ice_c_waitset_grouping.c
@@ -65,7 +65,7 @@ int main()
         subscriber[i] =
             iox_sub_init(&(subscriberStorage[i]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
 
-        iox_sub_subscribe(subscriber[i], queueCapacity);
+        iox_sub_subscribe(subscriber[i]);
     }
 
     const uint64_t FIRST_GROUP_ID = 123U;

--- a/iceoryx_examples/waitset_on_c/ice_c_waitset_grouping.c
+++ b/iceoryx_examples/waitset_on_c/ice_c_waitset_grouping.c
@@ -58,12 +58,14 @@ int main()
     iox_sub_t subscriber[NUMBER_OF_SUBSCRIBERS];
 
     // create subscriber and subscribe them to our service
-    uint64_t historyRequest = 1U;
+    const uint64_t historyRequest = 1U;
+    const uint64_t queueCapacity = 256U;
     for (uint64_t i = 0U; i < NUMBER_OF_SUBSCRIBERS; ++i)
     {
-        subscriber[i] = iox_sub_init(&(subscriberStorage[i]), "Radar", "FrontLeft", "Counter", historyRequest);
+        subscriber[i] =
+            iox_sub_init(&(subscriberStorage[i]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
 
-        iox_sub_subscribe(subscriber[i], 256);
+        iox_sub_subscribe(subscriber[i], queueCapacity);
     }
 
     const uint64_t FIRST_GROUP_ID = 123U;

--- a/iceoryx_examples/waitset_on_c/ice_c_waitset_individual.c
+++ b/iceoryx_examples/waitset_on_c/ice_c_waitset_individual.c
@@ -65,8 +65,8 @@ int main()
     subscriber[1] =
         iox_sub_init(&(subscriberStorage[1]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
 
-    iox_sub_subscribe(subscriber[0], queueCapacity);
-    iox_sub_subscribe(subscriber[1], queueCapacity);
+    iox_sub_subscribe(subscriber[0]);
+    iox_sub_subscribe(subscriber[1]);
 
     iox_ws_attach_subscriber_event(waitSet, subscriber[0U], SubscriberEvent_HAS_SAMPLES, 0U, NULL);
     iox_ws_attach_subscriber_event(waitSet, subscriber[1U], SubscriberEvent_HAS_SAMPLES, 0U, NULL);

--- a/iceoryx_examples/waitset_on_c/ice_c_waitset_individual.c
+++ b/iceoryx_examples/waitset_on_c/ice_c_waitset_individual.c
@@ -58,12 +58,15 @@ int main()
     iox_sub_t subscriber[NUMBER_OF_SUBSCRIBERS];
 
     // create two subscribers, subscribe to the service and attach them to the waitset
-    uint64_t historyRequest = 1U;
-    subscriber[0] = iox_sub_init(&(subscriberStorage[0U]), "Radar", "FrontLeft", "Counter", historyRequest);
-    subscriber[1] = iox_sub_init(&(subscriberStorage[1U]), "Radar", "FrontLeft", "Counter", historyRequest);
+    const uint64_t historyRequest = 1U;
+    const uint64_t queueCapacity = 256U;
+    subscriber[0] =
+        iox_sub_init(&(subscriberStorage[0]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
+    subscriber[1] =
+        iox_sub_init(&(subscriberStorage[1]), "Radar", "FrontLeft", "Counter", queueCapacity, historyRequest);
 
-    iox_sub_subscribe(subscriber[0], 256);
-    iox_sub_subscribe(subscriber[1], 256);
+    iox_sub_subscribe(subscriber[0], queueCapacity);
+    iox_sub_subscribe(subscriber[1], queueCapacity);
 
     iox_ws_attach_subscriber_event(waitSet, subscriber[0U], SubscriberEvent_HAS_SAMPLES, 0U, NULL);
     iox_ws_attach_subscriber_event(waitSet, subscriber[1U], SubscriberEvent_HAS_SAMPLES, 0U, NULL);

--- a/iceoryx_posh/include/iceoryx_posh/gateway/channel.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/gateway/channel.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 
 #include "iceoryx_posh/capro/service_description.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
+#include "iceoryx_posh/popo/publisher_options.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/expected.hpp"
 #include "iceoryx_utils/cxx/optional.hpp"
 #include "iceoryx_utils/internal/objectpool/objectpool.hpp"
@@ -67,9 +69,12 @@ class Channel
     ///
     /// @brief create Creates a channel for the given service whose terminals reside in a static object pool.
     /// @param service The service to create the channel for.
+    /// @param options The PublisherOptions or SubscriberOptions with historyCapacity and queueCapacity.
     /// @return A copy of the created channel, if successful.
     ///
-    static cxx::expected<Channel, ChannelError> create(const capro::ServiceDescription& service) noexcept;
+    template <typename IceoryxPubSubOptions>
+    static cxx::expected<Channel, ChannelError> create(const capro::ServiceDescription& service,
+                                                       const IceoryxPubSubOptions& options) noexcept;
 
     capro::ServiceDescription getServiceDescription() const noexcept;
     IceoryxTerminalPtr getIceoryxTerminal() const noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/gateway/gateway_generic.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/gateway/gateway_generic.hpp
@@ -20,6 +20,8 @@
 #include "iceoryx_posh/gateway/gateway_config.hpp"
 #include "iceoryx_posh/iceoryx_posh_config.hpp"
 #include "iceoryx_posh/iceoryx_posh_types.hpp"
+#include "iceoryx_posh/popo/publisher_options.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/expected.hpp"
 #include "iceoryx_utils/cxx/function_ref.hpp"
 #include "iceoryx_utils/cxx/optional.hpp"
@@ -95,6 +97,7 @@ class GatewayGeneric : public gateway_t
     /// @brief addChannel Creates a channel for the given service and stores a copy of it in an internal collection for
     /// later access.
     /// @param service The service to create a channel for.
+    /// @param options The PublisherOptions or SubscriberOptions with historyCapacity and queueCapacity.
     /// @return an expected containing a copy of the added channel, otherwise an error
     ///
     /// @note Wildcard services are not allowed and will be ignored.
@@ -107,7 +110,11 @@ class GatewayGeneric : public gateway_t
     /// The service description is perhaps too large for copying since they contain strings, however this should be
     /// addressed with a service description repository feature.
     ///
-    cxx::expected<channel_t, GatewayError> addChannel(const capro::ServiceDescription& service) noexcept;
+    template <typename IceoryxPubSubOptions>
+    cxx::expected<channel_t, GatewayError> addChannel(const capro::ServiceDescription& service,
+                                                      const IceoryxPubSubOptions& options) noexcept;
+    cxx::expected<channel_t, GatewayError> addChannel(const capro::ServiceDescription& service,
+                                                      const popo::SubscriberOptions& subscriberOptions) noexcept;
 
     ///
     /// @brief findChannel Searches for a channel for the given service in the internally stored collection and returns

--- a/iceoryx_posh/include/iceoryx_posh/gateway/gateway_generic.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/gateway/gateway_generic.hpp
@@ -113,8 +113,6 @@ class GatewayGeneric : public gateway_t
     template <typename IceoryxPubSubOptions>
     cxx::expected<channel_t, GatewayError> addChannel(const capro::ServiceDescription& service,
                                                       const IceoryxPubSubOptions& options) noexcept;
-    cxx::expected<channel_t, GatewayError> addChannel(const capro::ServiceDescription& service,
-                                                      const popo::SubscriberOptions& subscriberOptions) noexcept;
 
     ///
     /// @brief findChannel Searches for a channel for the given service in the internally stored collection and returns

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/channel.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -47,19 +47,21 @@ inline constexpr Channel<IceoryxTerminal, ExternalTerminal>::Channel(
 }
 
 template <typename IceoryxTerminal, typename ExternalTerminal>
-constexpr inline bool
-Channel<IceoryxTerminal, ExternalTerminal>::operator==(const Channel<IceoryxTerminal, ExternalTerminal>& rhs) const
-    noexcept
+constexpr inline bool Channel<IceoryxTerminal, ExternalTerminal>::operator==(
+    const Channel<IceoryxTerminal, ExternalTerminal>& rhs) const noexcept
 {
     return m_service == rhs.getService();
 }
 
 template <typename IceoryxTerminal, typename ExternalTerminal>
+template <typename IceoryxPubSubOptions>
 inline cxx::expected<Channel<IceoryxTerminal, ExternalTerminal>, ChannelError>
-Channel<IceoryxTerminal, ExternalTerminal>::create(const capro::ServiceDescription& service) noexcept
+Channel<IceoryxTerminal, ExternalTerminal>::create(const capro::ServiceDescription& service,
+                                                   const IceoryxPubSubOptions& options) noexcept
 {
     // Create objects in the pool.
-    auto rawIceoryxTerminalPtr = s_iceoryxTerminals.create(std::forward<const capro::ServiceDescription>(service));
+    auto rawIceoryxTerminalPtr = s_iceoryxTerminals.create(std::forward<const capro::ServiceDescription&>(service),
+                                                           std::forward<const IceoryxPubSubOptions&>(options));
     if (rawIceoryxTerminalPtr == nullptr)
     {
         return cxx::error<ChannelError>(ChannelError::OBJECT_POOL_FULL);
@@ -93,8 +95,8 @@ inline std::shared_ptr<IceoryxTerminal> Channel<IceoryxTerminal, ExternalTermina
 }
 
 template <typename IceoryxTerminal, typename ExternalTerminal>
-inline std::shared_ptr<ExternalTerminal> Channel<IceoryxTerminal, ExternalTerminal>::getExternalTerminal() const
-    noexcept
+inline std::shared_ptr<ExternalTerminal>
+Channel<IceoryxTerminal, ExternalTerminal>::getExternalTerminal() const noexcept
 {
     return m_externalTerminal;
 }

--- a/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/gateway/gateway_generic.inl
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,8 +70,10 @@ inline GatewayGeneric<channel_t, gateway_t>::GatewayGeneric(capro::Interfaces in
 }
 
 template <typename channel_t, typename gateway_t>
+template <typename IceoryxPubSubOptions>
 inline cxx::expected<channel_t, GatewayError>
-GatewayGeneric<channel_t, gateway_t>::addChannel(const capro::ServiceDescription& service) noexcept
+GatewayGeneric<channel_t, gateway_t>::addChannel(const capro::ServiceDescription& service,
+                                                 const IceoryxPubSubOptions& options) noexcept
 {
     // Filter out wildcard services
     if (service.getServiceID() == capro::AnyService || service.getInstanceID() == capro::AnyInstance
@@ -88,7 +90,7 @@ GatewayGeneric<channel_t, gateway_t>::addChannel(const capro::ServiceDescription
     }
     else
     {
-        auto result = channel_t::create(service);
+        auto result = channel_t::create(service, options);
         if (result.has_error())
         {
             return cxx::error<GatewayError>(GatewayError::UNSUCCESSFUL_CHANNEL_CREATION);
@@ -121,8 +123,8 @@ GatewayGeneric<channel_t, gateway_t>::findChannel(const iox::capro::ServiceDescr
 }
 
 template <typename channel_t, typename gateway_t>
-inline void GatewayGeneric<channel_t, gateway_t>::forEachChannel(const cxx::function_ref<void(channel_t&)> f) const
-    noexcept
+inline void
+GatewayGeneric<channel_t, gateway_t>::forEachChannel(const cxx::function_ref<void(channel_t&)> f) const noexcept
 {
     auto guardedVector = m_channels.GetScopeGuard();
     for (auto channel = guardedVector->begin(); channel != guardedVector->end(); ++channel)

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_publisher.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_publisher.inl
@@ -24,7 +24,7 @@ namespace popo
 template <typename T, typename port_t>
 inline BasePublisher<T, port_t>::BasePublisher(const capro::ServiceDescription& service,
                                                const PublisherOptions& publisherOptions)
-    : m_port(iox::runtime::PoshRuntime::getInstance().getMiddlewarePublisher(service, publisherOptions.historyCapacity))
+    : m_port(iox::runtime::PoshRuntime::getInstance().getMiddlewarePublisher(service, publisherOptions))
 {
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -27,8 +27,9 @@ inline BaseSubscriber<T, Subscriber, port_t>::BaseSubscriber() noexcept
 }
 
 template <typename T, typename Subscriber, typename port_t>
-inline BaseSubscriber<T, Subscriber, port_t>::BaseSubscriber(const capro::ServiceDescription& service) noexcept
-    : m_port(iox::runtime::PoshRuntime::getInstance().getMiddlewareSubscriber(service))
+inline BaseSubscriber<T, Subscriber, port_t>::BaseSubscriber(const capro::ServiceDescription& service,
+                                                             const SubscriberOptions& subscriberOptions) noexcept
+    : m_port(iox::runtime::PoshRuntime::getInstance().getMiddlewareSubscriber(service, subscriberOptions))
 {
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/base_subscriber.inl
@@ -53,9 +53,9 @@ BaseSubscriber<T, Subscriber, port_t>::getServiceDescription() const noexcept
 }
 
 template <typename T, typename Subscriber, typename port_t>
-inline void BaseSubscriber<T, Subscriber, port_t>::subscribe(const uint64_t queueCapacity) noexcept
+inline void BaseSubscriber<T, Subscriber, port_t>::subscribe() noexcept
 {
-    m_port.subscribe(queueCapacity);
+    m_port.subscribe();
 }
 
 template <typename T, typename Subscriber, typename port_t>

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/publisher_port_data.hpp
@@ -37,7 +37,7 @@ struct PublisherPortData : public BasePortData
     PublisherPortData(const capro::ServiceDescription& serviceDescription,
                       const ProcessName_t& processName,
                       mepoo::MemoryManager* const memoryManager,
-                      const PublisherOptions& publisherOptions = PublisherOptions(),
+                      const PublisherOptions& publisherOptions,
                       const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
     using ChunkQueueData_t = SubscriberPortData::ChunkQueueData_t;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -20,7 +20,6 @@
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
-#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/variant_queue.hpp"
 
 #include <atomic>
@@ -29,12 +28,14 @@ namespace iox
 {
 namespace popo
 {
+struct SubscriberOptions;
+
 struct SubscriberPortData : public BasePortData
 {
     SubscriberPortData(const capro::ServiceDescription& serviceDescription,
                        const ProcessName_t& processName,
                        cxx::VariantQueueTypes queueType,
-                       const SubscriberOptions& subscriberOptions = SubscriberOptions(),
+                       const SubscriberOptions& subscriberOptions,
                        const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
     using ChunkQueueData_t = ChunkQueueData<DefaultChunkQueueConfig, ThreadSafePolicy>;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp
@@ -20,6 +20,7 @@
 #include "iceoryx_posh/internal/popo/building_blocks/chunk_receiver_data.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/locking_policy.hpp"
 #include "iceoryx_posh/internal/popo/ports/base_port_data.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/variant_queue.hpp"
 
 #include <atomic>
@@ -33,7 +34,7 @@ struct SubscriberPortData : public BasePortData
     SubscriberPortData(const capro::ServiceDescription& serviceDescription,
                        const ProcessName_t& processName,
                        cxx::VariantQueueTypes queueType,
-                       const uint64_t& historyRequest = 0u,
+                       const SubscriberOptions& subscriberOptions = SubscriberOptions(),
                        const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
     using ChunkQueueData_t = ChunkQueueData<DefaultChunkQueueConfig, ThreadSafePolicy>;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp
@@ -19,6 +19,7 @@
 #include "iceoryx_posh/internal/popo/ports/base_port.hpp"
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp"
 #include "iceoryx_posh/mepoo/chunk_header.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/expected.hpp"
 #include "iceoryx_utils/cxx/helplets.hpp"
 #include "iceoryx_utils/cxx/optional.hpp"
@@ -47,9 +48,7 @@ class SubscriberPortUser : public BasePort
     ~SubscriberPortUser() = default;
 
     /// @brief try to subscribe to all matching publishers
-    /// @param[in] queueCapacity, capacity of the queue where chunks are stored before they are passed to the user with
-    /// tryGetChunk. Caution: Depending on the underlying queue there can be a different overflow behavior
-    void subscribe(const uint64_t queueCapacity = MemberType_t::ChunkQueueData_t::MAX_CAPACITY) noexcept;
+    void subscribe() noexcept;
 
     /// @brief unsubscribe from publishers, if there are any to which we are currently subscribed
     void unsubscribe() noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/typed_subscriber.inl
@@ -20,8 +20,9 @@ namespace iox
 namespace popo
 {
 template <typename T, template <typename, typename, typename> class base_subscriber_t>
-inline TypedSubscriber<T, base_subscriber_t>::TypedSubscriber(const capro::ServiceDescription& service)
-    : BaseSubscriber(service)
+inline TypedSubscriber<T, base_subscriber_t>::TypedSubscriber(const capro::ServiceDescription& service,
+                                                              const SubscriberOptions& subscriberOptions)
+    : BaseSubscriber(service, subscriberOptions)
 {
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
+++ b/iceoryx_posh/include/iceoryx_posh/internal/popo/untyped_subscriber.inl
@@ -20,8 +20,9 @@ namespace iox
 namespace popo
 {
 template <template <typename, typename, typename> class base_subscriber_t>
-inline UntypedSubscriberImpl<base_subscriber_t>::UntypedSubscriberImpl(const capro::ServiceDescription& service)
-    : BaseSubscriber(service)
+inline UntypedSubscriberImpl<base_subscriber_t>::UntypedSubscriberImpl(const capro::ServiceDescription& service,
+                                                                       const SubscriberOptions& subscriberOptions)
+    : BaseSubscriber(service, subscriberOptions)
 {
 }
 

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/port_manager.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/port_manager.hpp
@@ -63,7 +63,7 @@ class PortManager
 
     cxx::expected<PublisherPortRouDiType::MemberType_t*, PortPoolError>
     acquirePublisherPortData(const capro::ServiceDescription& service,
-                             const uint64_t& historyCapacity,
+                             const popo::PublisherOptions& publisherOptions,
                              const ProcessName_t& processName,
                              mepoo::MemoryManager* payloadMemoryManager,
                              const NodeName_t& node,
@@ -71,7 +71,7 @@ class PortManager
 
     cxx::expected<SubscriberPortType::MemberType_t*, PortPoolError>
     acquireSubscriberPortData(const capro::ServiceDescription& service,
-                              const uint64_t& historyRequest,
+                              const popo::SubscriberOptions& subscriberOptions,
                               const ProcessName_t& processName,
                               const NodeName_t& node,
                               const PortConfigInfo& portConfigInfo) noexcept;

--- a/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi_process.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/internal/roudi/roudi_process.hpp
@@ -146,13 +146,13 @@ class ProcessManager : public ProcessManagerInterface
 
     void addSubscriberForProcess(const ProcessName_t& name,
                                  const capro::ServiceDescription& service,
-                                 const uint64_t& historyRequest,
+                                 const popo::SubscriberOptions& subscriberOptions,
                                  const NodeName_t& node,
                                  const PortConfigInfo& portConfigInfo = PortConfigInfo()) noexcept;
 
     void addPublisherForProcess(const ProcessName_t& name,
                                 const capro::ServiceDescription& service,
-                                const uint64_t& historyCapacity,
+                                const popo::PublisherOptions& publisherOptions,
                                 const NodeName_t& node,
                                 const PortConfigInfo& portConfigInfo = PortConfigInfo()) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -17,6 +17,7 @@
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp"
 #include "iceoryx_posh/popo/sample.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_posh/popo/wait_set.hpp"
 #include "iceoryx_posh/runtime/posh_runtime.hpp"
 #include "iceoryx_utils/cxx/expected.hpp"
@@ -67,11 +68,9 @@ class BaseSubscriber
 
     ///
     /// @brief subscribe Initiate subscription.
-    /// @param queueCapacity
     /// @return
     ///
-    void
-    subscribe(const uint64_t queueCapacity = SubscriberPortUser::MemberType_t::ChunkQueueData_t::MAX_CAPACITY) noexcept;
+    void subscribe() noexcept;
 
     ///
     /// @brief getSubscriptionState Get current subscription state.

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -114,7 +114,8 @@ class BaseSubscriber
 
   protected:
     BaseSubscriber() noexcept; // Required for testing.
-    BaseSubscriber(const capro::ServiceDescription& service) noexcept;
+    BaseSubscriber(const capro::ServiceDescription& service,
+                   const SubscriberOptions& subscriberOptions = SubscriberOptions()) noexcept;
 
     void invalidateTrigger(const uint64_t trigger) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/base_subscriber.hpp
@@ -113,8 +113,7 @@ class BaseSubscriber
 
   protected:
     BaseSubscriber() noexcept; // Required for testing.
-    BaseSubscriber(const capro::ServiceDescription& service,
-                   const SubscriberOptions& subscriberOptions = SubscriberOptions()) noexcept;
+    BaseSubscriber(const capro::ServiceDescription& service, const SubscriberOptions& subscriberOptions) noexcept;
 
     void invalidateTrigger(const uint64_t trigger) noexcept;
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
@@ -30,7 +30,7 @@ struct SubscriberOptions
     /// @attention Depending on the underlying queue there can be a different overflow behavior
     uint64_t queueCapacity{SubscriberPortData::ChunkQueueData_t::MAX_CAPACITY};
 
-    /// @brief The max number of chunks received as history after subscription
+    /// @brief The max number of chunks received after subscription if chunks are available
     uint64_t historyRequest{0U};
 };
 

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef IOX_POSH_POPO_PUBLISHER_OPTIONS_HPP
-#define IOX_POSH_POPO_PUBLISHER_OPTIONS_HPP
+#ifndef IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
+#define IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 
 #include <cstdint>
 
@@ -21,13 +21,16 @@ namespace iox
 {
 namespace popo
 {
-/// @brief This struct is used to configure the publisher
-struct PublisherOptions
+/// @brief This struct is used to configure the subscriber
+struct SubscriberOptions
 {
-    /// @brief The size of the history chunk queue
-    uint64_t historyCapacity{0U};
+    /// @brief The size of the receiver queue
+    uint64_t queueCapacity{1U};
+
+    /// @brief The max number of chunks received as history after subscription
+    uint64_t historyRequest{0U};
 };
 
 } // namespace popo
 } // namespace iox
-#endif // IOX_POSH_POPO_PUBLISHER_OPTIONS_HPP
+#endif // IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP

--- a/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/subscriber_options.hpp
@@ -15,6 +15,8 @@
 #ifndef IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 #define IOX_POSH_POPO_SUBSCRIBER_OPTIONS_HPP
 
+#include "iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp"
+
 #include <cstdint>
 
 namespace iox
@@ -24,8 +26,9 @@ namespace popo
 /// @brief This struct is used to configure the subscriber
 struct SubscriberOptions
 {
-    /// @brief The size of the receiver queue
-    uint64_t queueCapacity{1U};
+    /// @brief The size of the receiver queue where chunks are stored before they are passed to the user
+    /// @attention Depending on the underlying queue there can be a different overflow behavior
+    uint64_t queueCapacity{SubscriberPortData::ChunkQueueData_t::MAX_CAPACITY};
 
     /// @brief The max number of chunks received as history after subscription
     uint64_t historyRequest{0U};

--- a/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/typed_subscriber.hpp
@@ -28,7 +28,8 @@ class TypedSubscriber : public base_subscriber_t<T, TypedSubscriber<T, base_subs
     static_assert(!std::is_void<T>::value, "Type must not be void. Use the UntypedSubscriber for void types.");
 
   public:
-    TypedSubscriber(const capro::ServiceDescription& service);
+    TypedSubscriber(const capro::ServiceDescription& service,
+                    const SubscriberOptions& subscriberOptions = SubscriberOptions());
     TypedSubscriber(const TypedSubscriber& other) = delete;
     TypedSubscriber& operator=(const TypedSubscriber&) = delete;
     TypedSubscriber(TypedSubscriber&& rhs) = delete;

--- a/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/popo/untyped_subscriber.hpp
@@ -37,7 +37,8 @@ class UntypedSubscriberImpl
     using BaseSubscriber =
         base_subscriber_t<void, UntypedSubscriberImpl<base_subscriber_t>, iox::SubscriberPortUserType>;
 
-    UntypedSubscriberImpl(const capro::ServiceDescription& service);
+    UntypedSubscriberImpl(const capro::ServiceDescription& service,
+                          const SubscriberOptions& subscriberOptions = SubscriberOptions());
     UntypedSubscriberImpl(const UntypedSubscriberImpl& other) = delete;
     UntypedSubscriberImpl& operator=(const UntypedSubscriberImpl&) = delete;
     UntypedSubscriberImpl(UntypedSubscriberImpl&& rhs) = delete;

--- a/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.hpp
@@ -72,20 +72,20 @@ class PortPool
 
     cxx::expected<SubscriberPortType::MemberType_t*, PortPoolError>
     addSubscriberPort(const capro::ServiceDescription& serviceDescription,
-                      const uint64_t& historyRequest,
                       const ProcessName_t& applicationName,
+                      const popo::SubscriberOptions& subscriberOptions,
                       const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
     template <typename T, std::enable_if_t<std::is_same<T, iox::build::ManyToManyPolicy>::value>* = nullptr>
     iox::popo::SubscriberPortData* constructSubscriber(const capro::ServiceDescription& serviceDescription,
-                                                       const uint64_t& historyRequest,
                                                        const ProcessName_t& applicationName,
+                                                       const popo::SubscriberOptions& subscriberOptions,
                                                        const mepoo::MemoryInfo& memoryInfo) noexcept;
 
     template <typename T, std::enable_if_t<std::is_same<T, iox::build::OneToManyPolicy>::value>* = nullptr>
     iox::popo::SubscriberPortData* constructSubscriber(const capro::ServiceDescription& serviceDescription,
-                                                       const uint64_t& historyRequest,
                                                        const ProcessName_t& applicationName,
+                                                       const popo::SubscriberOptions& subscriberOptions,
                                                        const mepoo::MemoryInfo& memoryInfo) noexcept;
 
     cxx::expected<popo::InterfacePortData*, PortPoolError> addInterfacePort(const ProcessName_t& applicationName,

--- a/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.hpp
@@ -67,7 +67,7 @@ class PortPool
     addPublisherPort(const capro::ServiceDescription& serviceDescription,
                      mepoo::MemoryManager* const memoryManager,
                      const ProcessName_t& applicationName,
-                     const popo::PublisherOptions& publisherOptions = popo::PublisherOptions(),
+                     const popo::PublisherOptions& publisherOptions,
                      const mepoo::MemoryInfo& memoryInfo = mepoo::MemoryInfo()) noexcept;
 
     cxx::expected<SubscriberPortType::MemberType_t*, PortPoolError>

--- a/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.inl
+++ b/iceoryx_posh/include/iceoryx_posh/roudi/port_pool.inl
@@ -20,27 +20,27 @@ namespace roudi
 {
 template <typename T, std::enable_if_t<std::is_same<T, iox::build::ManyToManyPolicy>::value>*>
 inline iox::popo::SubscriberPortData* PortPool::constructSubscriber(const capro::ServiceDescription& serviceDescription,
-                                                                    const uint64_t& historyRequest,
                                                                     const ProcessName_t& applicationName,
+                                                                    const popo::SubscriberOptions& subscriberOptions,
                                                                     const mepoo::MemoryInfo& memoryInfo) noexcept
 {
     return m_portPoolData->m_subscriberPortMembers.insert(serviceDescription,
                                                           applicationName,
                                                           cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer,
-                                                          historyRequest,
+                                                          subscriberOptions,
                                                           memoryInfo);
 }
 
 template <typename T, std::enable_if_t<std::is_same<T, iox::build::OneToManyPolicy>::value>*>
 inline iox::popo::SubscriberPortData* PortPool::constructSubscriber(const capro::ServiceDescription& serviceDescription,
-                                                                    const uint64_t& historyRequest,
                                                                     const ProcessName_t& applicationName,
+                                                                    const popo::SubscriberOptions& subscriberOptions,
                                                                     const mepoo::MemoryInfo& memoryInfo) noexcept
 {
     return m_portPoolData->m_subscriberPortMembers.insert(serviceDescription,
                                                           applicationName,
                                                           cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
-                                                          historyRequest,
+                                                          subscriberOptions,
                                                           memoryInfo);
 }
 } // namespace roudi

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -24,6 +24,7 @@
 #include "iceoryx_posh/internal/runtime/message_queue_interface.hpp"
 #include "iceoryx_posh/internal/runtime/node_property.hpp"
 #include "iceoryx_posh/internal/runtime/shared_memory_user.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_posh/runtime/port_config_info.hpp"
 #include "iceoryx_utils/cxx/string.hpp"
 

--- a/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
+++ b/iceoryx_posh/include/iceoryx_posh/runtime/posh_runtime.hpp
@@ -84,27 +84,27 @@ class PoshRuntime
 
     /// @brief request the RouDi daemon to create a publisher port
     /// @param[in] serviceDescription service description for the new publisher port
-    /// @param[in] historyCapacity history capacity of a publisher
+    /// @param[in] publisherOptions like the history capacity of a publisher
     /// @param[in] nodeName name of the node where the publisher should belong to
     /// @param[in] portConfigInfo configuration information for the port
     /// (i.e. what type of port is requested, device where its payload memory is located on etc.)
     /// @return pointer to a created publisher port user
     PublisherPortUserType::MemberType_t*
     getMiddlewarePublisher(const capro::ServiceDescription& service,
-                           const uint64_t& historyCapacity = 0U,
+                           const popo::PublisherOptions& publisherOptions = popo::PublisherOptions(),
                            const NodeName_t& nodeName = "",
                            const PortConfigInfo& portConfigInfo = PortConfigInfo()) noexcept;
 
     /// @brief request the RouDi daemon to create a subscriber port
     /// @param[in] serviceDescription service description for the new subscriber port
-    /// @param[in] historyRequest history requested by a subscriber
+    /// @param[in] subscriberOptions like the queue capacity and history requested by a subscriber
     /// @param[in] nodeName name of the node where the subscriber should belong to
     /// @param[in] portConfigInfo configuration information for the port
     /// (what type of port is requested, device where its payload memory is located on etc.)
     /// @return pointer to a created subscriber port data
     SubscriberPortUserType::MemberType_t*
     getMiddlewareSubscriber(const capro::ServiceDescription& service,
-                            const uint64_t& historyRequest = 0U,
+                            const popo::SubscriberOptions& subscriberOptions = popo::SubscriberOptions(),
                             const NodeName_t& nodeName = "",
                             const PortConfigInfo& portConfigInfo = PortConfigInfo()) noexcept;
 

--- a/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
@@ -21,12 +21,13 @@ namespace popo
 SubscriberPortData::SubscriberPortData(const capro::ServiceDescription& serviceDescription,
                                        const ProcessName_t& processName,
                                        cxx::VariantQueueTypes queueType,
-                                       const uint64_t& historyRequest,
+                                       const SubscriberOptions& subscriberOptions,
                                        const mepoo::MemoryInfo& memoryInfo) noexcept
     : BasePortData(serviceDescription, processName)
     , m_chunkReceiverData(queueType, memoryInfo)
-    , m_historyRequest(historyRequest)
+    , m_historyRequest(subscriberOptions.historyRequest)
 {
+    m_chunkReceiverData.m_queue.setCapacity(subscriberOptions.queueCapacity);
 }
 
 } // namespace popo

--- a/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_data.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_data.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 
 namespace iox
 {

--- a/iceoryx_posh/source/popo/ports/subscriber_port_user.cpp
+++ b/iceoryx_posh/source/popo/ports/subscriber_port_user.cpp
@@ -37,30 +37,12 @@ SubscriberPortUser::MemberType_t* SubscriberPortUser::getMembers() noexcept
 }
 
 
-void SubscriberPortUser::subscribe(const uint64_t queueCapacity) noexcept
+void SubscriberPortUser::subscribe() noexcept
 {
     if (!getMembers()->m_subscribeRequested.load(std::memory_order_relaxed))
     {
         // start with new chunks, drop old ones that could be in the queue
         m_chunkReceiver.clear();
-
-        /// @todo is it safe to change the capacity when it is no more the initial subscribe?
-        /// What is the contract for changing the capacity?
-
-        uint64_t capacity = queueCapacity;
-        if (capacity > m_chunkReceiver.getMaximumCapacity())
-        {
-            LogWarn() << "Requested queue capacity " << queueCapacity
-                      << " exceeds the maximum possible one for this subscriber"
-                      << ", limiting to " << m_chunkReceiver.getMaximumCapacity();
-            capacity = m_chunkReceiver.getMaximumCapacity();
-        }
-
-        // only change the capacity if it has to be changed
-        if (m_chunkReceiver.getCurrentCapacity() != capacity)
-        {
-            m_chunkReceiver.setCapacity(capacity);
-        }
 
         getMembers()->m_subscribeRequested.store(true, std::memory_order_relaxed);
     }

--- a/iceoryx_posh/source/roudi/port_pool.cpp
+++ b/iceoryx_posh/source/roudi/port_pool.cpp
@@ -164,14 +164,14 @@ PortPool::addPublisherPort(const capro::ServiceDescription& serviceDescription,
 
 cxx::expected<SubscriberPortType::MemberType_t*, PortPoolError>
 PortPool::addSubscriberPort(const capro::ServiceDescription& serviceDescription,
-                            const uint64_t& historyRequest,
                             const ProcessName_t& applicationName,
+                            const popo::SubscriberOptions& subscriberOptions,
                             const mepoo::MemoryInfo& memoryInfo) noexcept
 {
     if (m_portPoolData->m_subscriberPortMembers.hasFreeSpace())
     {
         auto subscriberPortData = constructSubscriber<iox::build::CommunicationPolicy>(
-            serviceDescription, historyRequest, applicationName, memoryInfo);
+            serviceDescription, applicationName, subscriberOptions, memoryInfo);
 
         return cxx::success<SubscriberPortType::MemberType_t*>(subscriberPortData);
     }

--- a/iceoryx_posh/source/roudi/roudi.cpp
+++ b/iceoryx_posh/source/roudi/roudi.cpp
@@ -16,6 +16,7 @@
 #include "iceoryx_posh/internal/log/posh_logging.hpp"
 #include "iceoryx_posh/internal/runtime/message_queue_interface.hpp"
 #include "iceoryx_posh/internal/runtime/node_property.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_posh/roudi/introspection_types.hpp"
 #include "iceoryx_posh/roudi/memory/roudi_memory_manager.hpp"
 #include "iceoryx_posh/runtime/port_config_info.hpp"

--- a/iceoryx_posh/source/roudi/roudi.cpp
+++ b/iceoryx_posh/source/roudi/roudi.cpp
@@ -187,9 +187,12 @@ void RouDi::processMessage(const runtime::MqMessage& message,
             capro::ServiceDescription service(cxx::Serialization(message.getElementAtIndex(2)));
             cxx::Serialization portConfigInfoSerialization(message.getElementAtIndex(5));
 
+            popo::PublisherOptions options;
+            options.historyCapacity = std::stoull(message.getElementAtIndex(3));
+
             m_prcMgr.addPublisherForProcess(processName,
                                             service,
-                                            std::stoull(message.getElementAtIndex(3)),
+                                            options,
                                             NodeName_t(cxx::TruncateToCapacity, message.getElementAtIndex(4)),
                                             iox::runtime::PortConfigInfo(portConfigInfoSerialization));
         }
@@ -197,7 +200,7 @@ void RouDi::processMessage(const runtime::MqMessage& message,
     }
     case runtime::MqMessageType::CREATE_SUBSCRIBER:
     {
-        if (message.getNumberOfElements() != 6)
+        if (message.getNumberOfElements() != 7)
         {
             LogError() << "Wrong number of parameters for \"MqMessageType::CREATE_SUBSCRIBER\" from \"" << processName
                        << "\"received!";
@@ -205,12 +208,17 @@ void RouDi::processMessage(const runtime::MqMessage& message,
         else
         {
             capro::ServiceDescription service(cxx::Serialization(message.getElementAtIndex(2)));
-            cxx::Serialization portConfigInfoSerialization(message.getElementAtIndex(5));
+            cxx::Serialization portConfigInfoSerialization(message.getElementAtIndex(6));
+
+
+            popo::SubscriberOptions options;
+            options.historyRequest = std::stoull(message.getElementAtIndex(3));
+            options.queueCapacity = std::stoull(message.getElementAtIndex(4));
 
             m_prcMgr.addSubscriberForProcess(processName,
                                              service,
-                                             std::stoull(message.getElementAtIndex(3)),
-                                             NodeName_t(cxx::TruncateToCapacity, message.getElementAtIndex(4)),
+                                             options,
+                                             NodeName_t(cxx::TruncateToCapacity, message.getElementAtIndex(5)),
                                              iox::runtime::PortConfigInfo(portConfigInfoSerialization));
         }
         break;

--- a/iceoryx_posh/source/roudi/roudi_process.cpp
+++ b/iceoryx_posh/source/roudi/roudi_process.cpp
@@ -612,7 +612,7 @@ void ProcessManager::sendMessageNotSupportedToRuntime(const ProcessName_t& name)
 
 void ProcessManager::addSubscriberForProcess(const ProcessName_t& name,
                                              const capro::ServiceDescription& service,
-                                             const uint64_t& historyRequest,
+                                             const popo::SubscriberOptions& subscriberOptions,
                                              const NodeName_t& node,
                                              const PortConfigInfo& portConfigInfo) noexcept
 {
@@ -623,7 +623,7 @@ void ProcessManager::addSubscriberForProcess(const ProcessName_t& name,
     {
         // create a SubscriberPort
         auto maybeSubscriber =
-            m_portManager.acquireSubscriberPortData(service, historyRequest, name, node, portConfigInfo);
+            m_portManager.acquireSubscriberPortData(service, subscriberOptions, name, node, portConfigInfo);
 
         if (!maybeSubscriber.has_error())
         {
@@ -654,7 +654,7 @@ void ProcessManager::addSubscriberForProcess(const ProcessName_t& name,
 
 void ProcessManager::addPublisherForProcess(const ProcessName_t& name,
                                             const capro::ServiceDescription& service,
-                                            const uint64_t& historyCapacity,
+                                            const popo::PublisherOptions& publisherOptions,
                                             const NodeName_t& node,
                                             const PortConfigInfo& portConfigInfo) noexcept
 {
@@ -665,7 +665,7 @@ void ProcessManager::addPublisherForProcess(const ProcessName_t& name,
     {
         // create a PublisherPort
         auto maybePublisher = m_portManager.acquirePublisherPortData(
-            service, historyCapacity, name, process->getPayloadMemoryManager(), node, portConfigInfo);
+            service, publisherOptions, name, process->getPayloadMemoryManager(), node, portConfigInfo);
 
         if (!maybePublisher.has_error())
         {
@@ -752,8 +752,10 @@ popo::PublisherPortData* ProcessManager::addIntrospectionPublisherPort(const cap
 {
     std::lock_guard<std::mutex> g(m_mutex);
 
+    popo::PublisherOptions options;
+    options.historyCapacity = 1;
     auto maybePublisher = m_portManager.acquirePublisherPortData(
-        service, 1, process_name, m_introspectionMemoryManager, "runnable", PortConfigInfo());
+        service, options, process_name, m_introspectionMemoryManager, "runnable", PortConfigInfo());
 
     if (maybePublisher.has_error())
     {

--- a/iceoryx_posh/source/runtime/posh_runtime.cpp
+++ b/iceoryx_posh/source/runtime/posh_runtime.cpp
@@ -142,13 +142,14 @@ const std::atomic<uint64_t>* PoshRuntime::getServiceRegistryChangeCounter() noex
 }
 
 PublisherPortUserType::MemberType_t* PoshRuntime::getMiddlewarePublisher(const capro::ServiceDescription& service,
-                                                                         const uint64_t& historyCapacity,
+                                                                         const popo::PublisherOptions& publisherOptions,
                                                                          const NodeName_t& nodeName,
                                                                          const PortConfigInfo& portConfigInfo) noexcept
 {
     MqMessage sendBuffer;
     sendBuffer << mqMessageTypeToString(MqMessageType::CREATE_PUBLISHER) << m_appName
-               << static_cast<cxx::Serialization>(service).toString() << std::to_string(historyCapacity) << nodeName
+               << static_cast<cxx::Serialization>(service).toString()
+               << std::to_string(publisherOptions.historyCapacity) << nodeName
                << static_cast<cxx::Serialization>(portConfigInfo).toString();
 
     auto maybePublisher = requestPublisherFromRoudi(sendBuffer);
@@ -225,14 +226,15 @@ PoshRuntime::requestPublisherFromRoudi(const MqMessage& sendBuffer) noexcept
 
 SubscriberPortUserType::MemberType_t*
 PoshRuntime::getMiddlewareSubscriber(const capro::ServiceDescription& service,
-                                     const uint64_t& historyRequest,
+                                     const popo::SubscriberOptions& subscriberOptions,
                                      const NodeName_t& nodeName,
                                      const PortConfigInfo& portConfigInfo) noexcept
 {
     MqMessage sendBuffer;
     sendBuffer << mqMessageTypeToString(MqMessageType::CREATE_SUBSCRIBER) << m_appName
-               << static_cast<cxx::Serialization>(service).toString() << std::to_string(historyRequest) << nodeName
-               << static_cast<cxx::Serialization>(portConfigInfo).toString();
+               << static_cast<cxx::Serialization>(service).toString()
+               << std::to_string(subscriberOptions.historyRequest) << std::to_string(subscriberOptions.queueCapacity)
+               << nodeName << static_cast<cxx::Serialization>(portConfigInfo).toString();
 
     auto maybeSubscriber = requestSubscriberFromRoudi(sendBuffer);
 

--- a/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_chunk_building_blocks.cpp
@@ -38,7 +38,7 @@ struct DummySample
     uint64_t m_dummy{42};
 };
 
-static constexpr uint32_t NUM_CHUNKS_IN_POOL = 3 * iox::MAX_SUBSCRIBER_QUEUE_CAPACITY;
+static constexpr uint32_t NUM_CHUNKS_IN_POOL = 9 * iox::MAX_SUBSCRIBER_QUEUE_CAPACITY;
 static constexpr uint32_t SMALL_CHUNK = 128;
 static constexpr uint32_t CHUNK_META_INFO_SIZE = 256;
 static constexpr size_t MEMORY_SIZE = NUM_CHUNKS_IN_POOL * (SMALL_CHUNK + CHUNK_META_INFO_SIZE);
@@ -54,7 +54,7 @@ struct ChunkDistributorConfig
 
 struct ChunkQueueConfig
 {
-    static constexpr uint64_t MAX_QUEUE_CAPACITY = iox::MAX_SUBSCRIBER_QUEUE_CAPACITY;
+    static constexpr uint64_t MAX_QUEUE_CAPACITY = NUM_CHUNKS_IN_POOL / 3;
 };
 
 using ChunkQueueData_t = ChunkQueueData<ChunkQueueConfig, ThreadSafePolicy>;

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -114,14 +114,18 @@ class PortUser_IntegrationTest : public Test
     ConcurrentCaproMessageVector_t m_concurrentCaproMessageRx;
 
     // subscriber port for single producer
-    SubscriberPortData m_subscriberPortDataSingleProducer{
-        TEST_SERVICE_DESCRIPTION, TEST_SUBSCRIBER_APP_NAME, VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+    SubscriberPortData m_subscriberPortDataSingleProducer{TEST_SERVICE_DESCRIPTION,
+                                                          TEST_SUBSCRIBER_APP_NAME,
+                                                          VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+                                                          SubscriberOptions()};
     SubscriberPortUser m_subscriberPortUserSingleProducer{&m_subscriberPortDataSingleProducer};
     SubscriberPortSingleProducer m_subscriberPortRouDiSingleProducer{&m_subscriberPortDataSingleProducer};
 
     // subscriber port for multi producer
-    SubscriberPortData m_subscriberPortDataMultiProducer{
-        TEST_SERVICE_DESCRIPTION, TEST_SUBSCRIBER_APP_NAME, VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
+    SubscriberPortData m_subscriberPortDataMultiProducer{TEST_SERVICE_DESCRIPTION,
+                                                         TEST_SUBSCRIBER_APP_NAME,
+                                                         VariantQueueTypes::SoFi_MultiProducerSingleConsumer,
+                                                         SubscriberOptions()};
     SubscriberPortUser m_subscriberPortUserMultiProducer{&m_subscriberPortDataMultiProducer};
     SubscriberPortMultiProducer m_subscriberPortRouDiMultiProducer{&m_subscriberPortDataMultiProducer};
 

--- a/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
+++ b/iceoryx_posh/test/integrationtests/test_popo_port_user_building_blocks.cpp
@@ -76,7 +76,8 @@ class PortUser_IntegrationTest : public Test
 
             iox::ProcessName_t processName(TruncateToCapacity, publisherAppName.str().c_str());
 
-            m_publisherPortDataVector.emplace_back(TEST_SERVICE_DESCRIPTION, processName, &m_memoryManager);
+            m_publisherPortDataVector.emplace_back(
+                TEST_SERVICE_DESCRIPTION, processName, &m_memoryManager, PublisherOptions());
             m_publisherPortUserVector.emplace_back(&m_publisherPortDataVector.back());
             m_publisherPortRouDiVector.emplace_back(&m_publisherPortDataVector.back());
         }

--- a/iceoryx_posh/test/mocks/subscriber_mock.hpp
+++ b/iceoryx_posh/test/mocks/subscriber_mock.hpp
@@ -40,7 +40,7 @@ class MockSubscriberPortUser
         return getServiceDescription();
     }
     MOCK_CONST_METHOD0(getServiceDescription, iox::capro::ServiceDescription());
-    MOCK_METHOD1(subscribe, void(const uint64_t));
+    MOCK_METHOD0(subscribe, void());
     MOCK_METHOD0(unsubscribe, void());
     MOCK_CONST_METHOD0(getSubscriptionState, iox::SubscribeState());
     MOCK_METHOD0(
@@ -67,7 +67,7 @@ template <typename T, typename Child, typename Port>
 class MockBaseSubscriber
 {
   public:
-    MockBaseSubscriber(const iox::capro::ServiceDescription&){};
+    MockBaseSubscriber(const iox::capro::ServiceDescription&, const iox::popo::SubscriberOptions&){};
     MOCK_CONST_METHOD0(getUid, iox::popo::uid_t());
     MOCK_CONST_METHOD0(getServiceDescription, iox::capro::ServiceDescription());
     MOCK_METHOD1(subscribe, void(uint64_t));

--- a/iceoryx_posh/test/moduletests/test_base_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_base_port.cpp
@@ -73,7 +73,8 @@ SubscriberPortData* createPortData()
 {
     return new SubscriberPortData(SERVICE_DESCRIPTION_VALID,
                                   APP_NAME_FOR_SUBSCRIBER_PORTS,
-                                  iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer);
+                                  iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
+                                  SubscriberOptions());
 }
 template <>
 InterfacePortData* createPortData()

--- a/iceoryx_posh/test/moduletests/test_base_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_base_port.cpp
@@ -73,9 +73,7 @@ SubscriberPortData* createPortData()
 {
     return new SubscriberPortData(SERVICE_DESCRIPTION_VALID,
                                   APP_NAME_FOR_SUBSCRIBER_PORTS,
-                                  iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
-                                  1,
-                                  iox::mepoo::MemoryInfo());
+                                  iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer);
 }
 template <>
 InterfacePortData* createPortData()

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -35,7 +35,7 @@ TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
     constexpr uint16_t testEventID{2u};
     constexpr uint16_t testInstanceID{3u};
     ServiceDescription sd(testServiceID, testEventID, testInstanceID);
-    iox::popo::SubscriberPortData recData{sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, 1};
+    iox::popo::SubscriberPortData recData{sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer};
 
     CaproMessage testObj(CaproMessageType::OFFER, sd, CaproMessageSubType::SERVICE, &recData);
 

--- a/iceoryx_posh/test/moduletests/test_capro_message.cpp
+++ b/iceoryx_posh/test/moduletests/test_capro_message.cpp
@@ -15,6 +15,7 @@
 #include "iceoryx_posh/internal/capro/capro_message.hpp"
 #include "iceoryx_posh/internal/popo/building_blocks/typed_unique_id.hpp"
 #include "iceoryx_posh/internal/roudi/introspection/port_introspection.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 #include "iceoryx_utils/cxx/generic_raii.hpp"
 #include "test.hpp"
 
@@ -31,18 +32,19 @@ class CaproMessage_test : public Test
 
 TEST_F(CaproMessage_test, CTorSetsParametersCorrectly)
 {
-    constexpr uint16_t testServiceID{1u};
-    constexpr uint16_t testEventID{2u};
-    constexpr uint16_t testInstanceID{3u};
+    constexpr uint16_t testServiceID{1U};
+    constexpr uint16_t testEventID{2U};
+    constexpr uint16_t testInstanceID{3U};
     ServiceDescription sd(testServiceID, testEventID, testInstanceID);
-    iox::popo::SubscriberPortData recData{sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer};
+    iox::popo::SubscriberPortData recData{
+        sd, "foo", iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer, iox::popo::SubscriberOptions()};
 
     CaproMessage testObj(CaproMessageType::OFFER, sd, CaproMessageSubType::SERVICE, &recData);
 
     EXPECT_EQ(&recData, testObj.m_chunkQueueData);
     EXPECT_EQ(CaproMessageType::OFFER, testObj.m_type);
     EXPECT_EQ(CaproMessageSubType::SERVICE, testObj.m_subType);
-    EXPECT_EQ(0u, testObj.m_historyCapacity);
+    EXPECT_EQ(0U, testObj.m_historyCapacity);
     EXPECT_EQ(sd, testObj.m_serviceDescription);
 }
 

--- a/iceoryx_posh/test/moduletests/test_gw_channel.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_channel.cpp
@@ -27,7 +27,10 @@ using iox::capro::IdString_t;
 // We do not need real channel terminals to test the base class.
 struct StubbedIceoryxTerminal
 {
-    StubbedIceoryxTerminal(iox::capro::ServiceDescription){};
+    struct Options
+    {
+    };
+    StubbedIceoryxTerminal(const iox::capro::ServiceDescription&, const Options&){};
 };
 
 struct StubbedExternalTerminal
@@ -48,5 +51,6 @@ class ChannelTest : public Test
 // ======================================== Tests ======================================== //
 TEST_F(ChannelTest, ReturnsEmptyOptionalIfObjectPoolExhausted)
 {
-    auto channel = iox::gw::Channel<StubbedIceoryxTerminal, StubbedExternalTerminal>::create({"", "", ""});
+    auto channel = iox::gw::Channel<StubbedIceoryxTerminal, StubbedExternalTerminal>::create(
+        {"", "", ""}, StubbedIceoryxTerminal::Options());
 }

--- a/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
+++ b/iceoryx_posh/test/moduletests/test_gw_gateway_generic.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 by Robert Bosch GmbH. All rights reserved.
+// Copyright (c) 2020 by Robert Bosch GmbH, Apex.AI Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,7 +32,10 @@ using iox::capro::IdString_t;
 // We do not need real channel terminals to test the base class.
 struct StubbedIceoryxTerminal
 {
-    StubbedIceoryxTerminal(iox::capro::ServiceDescription){};
+    struct Options
+    {
+    };
+    StubbedIceoryxTerminal(const iox::capro::ServiceDescription&, const Options&){};
 };
 
 struct StubbedExternalTerminal
@@ -60,9 +63,9 @@ TEST_F(GatewayGenericTest, AddedChannelsAreStored)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(testService);
+    gw.addChannel(testService, StubbedIceoryxTerminal::Options());
 
-    EXPECT_EQ(1, gw.getNumberOfChannels());
+    EXPECT_EQ(1U, gw.getNumberOfChannels());
 }
 
 TEST_F(GatewayGenericTest, DoesNotAddDuplicateChannels)
@@ -73,10 +76,10 @@ TEST_F(GatewayGenericTest, DoesNotAddDuplicateChannels)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(testService);
-    gw.addChannel(testService);
+    gw.addChannel(testService, StubbedIceoryxTerminal::Options());
+    gw.addChannel(testService, StubbedIceoryxTerminal::Options());
 
-    EXPECT_EQ(1, gw.getNumberOfChannels());
+    EXPECT_EQ(1U, gw.getNumberOfChannels());
 }
 
 TEST_F(GatewayGenericTest, IgnoresWildcardServices)
@@ -91,17 +94,17 @@ TEST_F(GatewayGenericTest, IgnoresWildcardServices)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    auto resultOne = gw.addChannel(completeWildcardService);
-    auto resultTwo = gw.addChannel(wildcardServiceService);
-    auto resultThree = gw.addChannel(wildcardInstanceService);
-    auto resultFour = gw.addChannel(wildcardEventService);
+    auto resultOne = gw.addChannel(completeWildcardService, StubbedIceoryxTerminal::Options());
+    auto resultTwo = gw.addChannel(wildcardServiceService, StubbedIceoryxTerminal::Options());
+    auto resultThree = gw.addChannel(wildcardInstanceService, StubbedIceoryxTerminal::Options());
+    auto resultFour = gw.addChannel(wildcardEventService, StubbedIceoryxTerminal::Options());
 
     EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultOne.get_error());
     EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultTwo.get_error());
     EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultThree.get_error());
     EXPECT_EQ(iox::gw::GatewayError::UNSUPPORTED_SERVICE_TYPE, resultFour.get_error());
 
-    EXPECT_EQ(0, gw.getNumberOfChannels());
+    EXPECT_EQ(0U, gw.getNumberOfChannels());
 }
 
 TEST_F(GatewayGenericTest, ProperlyManagesMultipleChannels)
@@ -115,13 +118,13 @@ TEST_F(GatewayGenericTest, ProperlyManagesMultipleChannels)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(serviceOne);
-    gw.addChannel(serviceTwo);
-    gw.addChannel(serviceThree);
-    gw.addChannel(serviceFour);
+    gw.addChannel(serviceOne, StubbedIceoryxTerminal::Options());
+    gw.addChannel(serviceTwo, StubbedIceoryxTerminal::Options());
+    gw.addChannel(serviceThree, StubbedIceoryxTerminal::Options());
+    gw.addChannel(serviceFour, StubbedIceoryxTerminal::Options());
 
 
-    EXPECT_EQ(4, gw.getNumberOfChannels());
+    EXPECT_EQ(4U, gw.getNumberOfChannels());
     EXPECT_EQ(true, gw.findChannel(serviceOne).has_value());
     EXPECT_EQ(true, gw.findChannel(serviceTwo).has_value());
     EXPECT_EQ(true, gw.findChannel(serviceThree).has_value());
@@ -134,12 +137,13 @@ TEST_F(GatewayGenericTest, HandlesMaxmimumChannelCapacity)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    for (auto i = 0u; i < iox::MAX_CHANNEL_NUMBER; i++)
+    for (auto i = 0U; i < iox::MAX_CHANNEL_NUMBER; i++)
     {
         auto result = gw.addChannel(
             iox::capro::ServiceDescription(iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i)),
                                            iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i)),
-                                           iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i))));
+                                           iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i))),
+            StubbedIceoryxTerminal::Options());
         EXPECT_EQ(false, result.has_error());
     }
 
@@ -152,16 +156,17 @@ TEST_F(GatewayGenericTest, ThrowsErrorWhenExceedingMaximumChannelCapaicity)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    for (auto i = 0u; i < iox::MAX_CHANNEL_NUMBER; i++)
+    for (auto i = 0U; i < iox::MAX_CHANNEL_NUMBER; i++)
     {
         auto result = gw.addChannel(
             iox::capro::ServiceDescription(iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i)),
                                            iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i)),
-                                           iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i))));
+                                           iox::capro::IdString_t(iox::cxx::TruncateToCapacity, std::to_string(i))),
+            StubbedIceoryxTerminal::Options());
         EXPECT_EQ(false, result.has_error());
     }
 
-    auto result = gw.addChannel({"oneTooMany", "oneTooMany", "oneTooMany"});
+    auto result = gw.addChannel({"oneTooMany", "oneTooMany", "oneTooMany"}, StubbedIceoryxTerminal::Options());
     EXPECT_EQ(true, result.has_error());
     EXPECT_EQ(iox::gw::GatewayError::UNSUCCESSFUL_CHANNEL_CREATION, result.get_error());
 }
@@ -176,13 +181,13 @@ TEST_F(GatewayGenericTest, ThrowsErrorWhenAttemptingToRemoveNonexistantChannel)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(testServiceA);
-    gw.addChannel(testServiceB);
-    EXPECT_EQ(2, gw.getNumberOfChannels());
+    gw.addChannel(testServiceA, StubbedIceoryxTerminal::Options());
+    gw.addChannel(testServiceB, StubbedIceoryxTerminal::Options());
+    EXPECT_EQ(2U, gw.getNumberOfChannels());
 
     auto result = gw.discardChannel(testServiceC);
     EXPECT_EQ(true, result.has_error());
-    EXPECT_EQ(2, gw.getNumberOfChannels());
+    EXPECT_EQ(2U, gw.getNumberOfChannels());
 }
 
 TEST_F(GatewayGenericTest, DiscardedChannelsAreNotStored)
@@ -193,11 +198,11 @@ TEST_F(GatewayGenericTest, DiscardedChannelsAreNotStored)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(testService);
-    EXPECT_EQ(1, gw.getNumberOfChannels());
+    gw.addChannel(testService, StubbedIceoryxTerminal::Options());
+    EXPECT_EQ(1U, gw.getNumberOfChannels());
     auto result = gw.discardChannel(testService);
     EXPECT_EQ(false, result.has_error());
-    EXPECT_EQ(0, gw.getNumberOfChannels());
+    EXPECT_EQ(0U, gw.getNumberOfChannels());
 }
 
 TEST_F(GatewayGenericTest, FindChannelReturnsCopyOfFoundChannel)
@@ -208,7 +213,7 @@ TEST_F(GatewayGenericTest, FindChannelReturnsCopyOfFoundChannel)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(testService);
+    gw.addChannel(testService, StubbedIceoryxTerminal::Options());
     auto foundChannel = gw.findChannel(testService);
     EXPECT_EQ(true, foundChannel.has_value());
     if (foundChannel.has_value())
@@ -226,7 +231,7 @@ TEST_F(GatewayGenericTest, FindChannelGivesEmptyOptionalIfNoneFound)
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(storedChannelService);
+    gw.addChannel(storedChannelService, StubbedIceoryxTerminal::Options());
     auto foundChannel = gw.findChannel(notStoredChannelService);
     EXPECT_EQ(false, foundChannel.has_value());
 }
@@ -238,16 +243,16 @@ TEST_F(GatewayGenericTest, ForEachChannelExecutesGivenFunctionForAllStoredChanne
     auto testServiceB = iox::capro::ServiceDescription("serviceB", "instanceB", "eventB");
     auto testServiceC = iox::capro::ServiceDescription("serviceC", "instanceC", "eventC");
 
-    auto count = 0u;
+    auto count = 0U;
     auto f = [&count](TestChannel&) { count++; };
 
     TestGatewayGeneric gw{};
 
     // ===== Test
-    gw.addChannel(testServiceA);
-    gw.addChannel(testServiceB);
-    gw.addChannel(testServiceC);
+    gw.addChannel(testServiceA, StubbedIceoryxTerminal::Options());
+    gw.addChannel(testServiceB, StubbedIceoryxTerminal::Options());
+    gw.addChannel(testServiceC, StubbedIceoryxTerminal::Options());
     gw.forEachChannel(f);
 
-    EXPECT_EQ(3, count);
+    EXPECT_EQ(3U, count);
 }

--- a/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_base_subscriber.cpp
@@ -84,7 +84,7 @@ class BaseSubscriberTest : public Test
 TEST_F(BaseSubscriberTest, SubscribeCallForwardedToUnderlyingSubscriberPort)
 {
     // ===== Setup ===== //
-    EXPECT_CALL(sut.getMockedPort(), subscribe(iox::MAX_SUBSCRIBER_QUEUE_CAPACITY)).Times(1);
+    EXPECT_CALL(sut.getMockedPort(), subscribe()).Times(1);
     // ===== Test ===== //
     sut.subscribe();
     // ===== Verify ===== //

--- a/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_publisher_port.cpp
@@ -70,10 +70,11 @@ class PublisherPort_test : public Test
     iox::posix::Allocator m_memoryAllocator{m_memory, MEMORY_SIZE};
     iox::mepoo::MePooConfig m_mempoolconf;
     iox::mepoo::MemoryManager m_memoryManager;
+    iox::popo::PublisherOptions m_publisherOptions;
 
     // publisher port w/o history
     iox::popo::PublisherPortData m_publisherPortData{
-        iox::capro::ServiceDescription("a", "b", "c"), "myApp", &m_memoryManager};
+        iox::capro::ServiceDescription("a", "b", "c"), "myApp", &m_memoryManager, m_publisherOptions};
     iox::popo::PublisherPortRouDi m_sutRouDiSide{&m_publisherPortData};
     iox::popo::PublisherPortUser m_sutUserSide{&m_publisherPortData};
 

--- a/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_subscriber_port.cpp
@@ -20,6 +20,7 @@
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_multi_producer.hpp"
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_single_producer.hpp"
 #include "iceoryx_posh/internal/popo/ports/subscriber_port_user.hpp"
+#include "iceoryx_posh/popo/subscriber_options.hpp"
 
 #include "iceoryx_posh/mepoo/mepoo_config.hpp"
 #include "iceoryx_utils/error_handling/error_handling.hpp"
@@ -55,7 +56,10 @@ class SubscriberPortSingleProducer_test : public Test
     iox::cxx::GenericRAII m_uniqueRouDiId{[] { iox::popo::internal::setUniqueRouDiId(0); },
                                           [] { iox::popo::internal::unsetUniqueRouDiId(); }};
     iox::popo::SubscriberPortData m_subscriberPortDataSingleProducer{
-        TEST_SERVICE_DESCRIPTION, "myApp", iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer};
+        TEST_SERVICE_DESCRIPTION,
+        "myApp",
+        iox::cxx::VariantQueueTypes::SoFi_SingleProducerSingleConsumer,
+        iox::popo::SubscriberOptions()};
     iox::popo::SubscriberPortUser m_sutUserSideSingleProducer{&m_subscriberPortDataSingleProducer};
     iox::popo::SubscriberPortSingleProducer m_sutRouDiSideSingleProducer{&m_subscriberPortDataSingleProducer};
 };
@@ -343,7 +347,8 @@ class SubscriberPortMultiProducer_test : public Test
     iox::popo::SubscriberPortData m_subscriberPortDataMultiProducer{
         SubscriberPortSingleProducer_test::TEST_SERVICE_DESCRIPTION,
         "myApp",
-        iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer};
+        iox::cxx::VariantQueueTypes::SoFi_MultiProducerSingleConsumer,
+        iox::popo::SubscriberOptions()};
     iox::popo::SubscriberPortUser m_sutUserSideMultiProducer{&m_subscriberPortDataMultiProducer};
     iox::popo::SubscriberPortMultiProducer m_sutRouDiSideMultiProducer{&m_subscriberPortDataMultiProducer};
 };

--- a/iceoryx_posh/test/moduletests/test_popo_typed_subscriber.cpp
+++ b/iceoryx_posh/test/moduletests/test_popo_typed_subscriber.cpp
@@ -43,7 +43,7 @@ class TypedSubscriberTest : public Test
     }
 
   protected:
-    TestTypedSubscriber sut{{"", "", ""}};
+    TestTypedSubscriber sut{{"", "", ""}, iox::popo::SubscriberOptions()};
 };
 
 TEST_F(TypedSubscriberTest, GetsUIDViaBaseSubscriber)
@@ -136,4 +136,3 @@ TEST_F(TypedSubscriberTest, ReleasesQueuedSamplesViaBaseSubscriber)
     // ===== Verify ===== //
     // ===== Cleanup ===== //
 }
-

--- a/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
+++ b/iceoryx_posh/test/moduletests/test_posh_runtime.cpp
@@ -242,11 +242,16 @@ TEST_F(PoshRuntime_test, SendRequestToRouDiInvalidMessage)
 
 TEST_F(PoshRuntime_test, GetMiddlewarePublisherIsSuccessful)
 {
-    const auto publisherPort = m_runtime->getMiddlewarePublisher(
-        iox::capro::ServiceDescription(99U, 1U, 20U), 0U, m_nodeName, iox::runtime::PortConfigInfo(11U, 22U, 33U));
+    iox::popo::PublisherOptions publisherOptions;
+    publisherOptions.historyCapacity = 13U;
+    const auto publisherPort = m_runtime->getMiddlewarePublisher(iox::capro::ServiceDescription(99U, 1U, 20U),
+                                                                 publisherOptions,
+                                                                 m_nodeName,
+                                                                 iox::runtime::PortConfigInfo(11U, 22U, 33U));
 
     ASSERT_NE(nullptr, publisherPort);
     EXPECT_EQ(iox::capro::ServiceDescription(99U, 1U, 20U), publisherPort->m_serviceDescription);
+    EXPECT_EQ(publisherOptions.historyCapacity, publisherPort->m_chunkSenderData.m_historyCapacity);
 }
 
 TEST_F(PoshRuntime_test, getMiddlewarePublisherDefaultArgs)
@@ -296,10 +301,10 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithSameServiceDescriptionsAndOne
     auto sameServiceDescription = iox::capro::ServiceDescription(99U, 1U, 20U);
 
     const auto publisherPort1 = m_runtime->getMiddlewarePublisher(
-        sameServiceDescription, 0U, m_nodeName, iox::runtime::PortConfigInfo(11U, 22U, 33U));
+        sameServiceDescription, iox::popo::PublisherOptions(), m_nodeName, iox::runtime::PortConfigInfo(11U, 22U, 33U));
 
     const auto publisherPort2 = m_runtime->getMiddlewarePublisher(
-        sameServiceDescription, 0U, m_nodeName, iox::runtime::PortConfigInfo(11U, 22U, 33U));
+        sameServiceDescription, iox::popo::PublisherOptions(), m_nodeName, iox::runtime::PortConfigInfo(11U, 22U, 33U));
 
     ASSERT_NE(nullptr, publisherPort1);
 
@@ -316,12 +321,18 @@ TEST_F(PoshRuntime_test, GetMiddlewarePublisherWithSameServiceDescriptionsAndOne
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberIsSuccessful)
 {
-    auto subscriberPort = m_runtime->getMiddlewareSubscriber(
-        iox::capro::ServiceDescription(99U, 1U, 20U), 0U, m_nodeName, iox::runtime::PortConfigInfo(11U, 22U, 33U));
+    iox::popo::SubscriberOptions subscriberOptions;
+    subscriberOptions.historyRequest = 13U;
+    subscriberOptions.queueCapacity = 42U;
+    auto subscriberPort = m_runtime->getMiddlewareSubscriber(iox::capro::ServiceDescription(99U, 1U, 20U),
+                                                             subscriberOptions,
+                                                             m_nodeName,
+                                                             iox::runtime::PortConfigInfo(11U, 22U, 33U));
 
     ASSERT_NE(nullptr, subscriberPort);
     EXPECT_EQ(iox::capro::ServiceDescription(99U, 1U, 20U), subscriberPort->m_serviceDescription);
-    EXPECT_EQ(0U, subscriberPort->m_historyRequest);
+    EXPECT_EQ(subscriberOptions.historyRequest, subscriberPort->m_historyRequest);
+    EXPECT_EQ(subscriberOptions.queueCapacity, subscriberPort->m_chunkReceiverData.m_queue.capacity());
 }
 
 TEST_F(PoshRuntime_test, GetMiddlewareSubscriberDefaultArgs)

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -220,8 +220,9 @@ TEST_F(PortIntrospection_test, addAndRemovePublisher)
         expected2.m_caproServiceID, expected2.m_caproInstanceID, expected2.m_caproEventMethodID);
 
     iox::mepoo::MemoryManager memoryManager;
-    iox::popo::PublisherPortData portData1(service1, processName1, &memoryManager);
-    iox::popo::PublisherPortData portData2(service2, processName2, &memoryManager);
+    iox::popo::PublisherOptions publisherOptions;
+    iox::popo::PublisherPortData portData1(service1, processName1, &memoryManager, publisherOptions);
+    iox::popo::PublisherPortData portData2(service2, processName2, &memoryManager, publisherOptions);
     // test adding of ports
     // remark: duplicate publisher port insertions are not possible
     EXPECT_THAT(m_introspectionAccess.addPublisher(&portData1, processName1, service1, nodeName1), Eq(true));
@@ -473,7 +474,8 @@ TEST_F(PortIntrospection_test, reportMessageToEstablishConnection)
                                            iox::popo::SubscriberOptions()};
     EXPECT_THAT(m_introspectionAccess.addSubscriber(&recData1, nameSubscriber, service, nodeName), Eq(true));
     iox::mepoo::MemoryManager memoryManager;
-    iox::popo::PublisherPortData publisherPortData{service, namePublisher, &memoryManager};
+    iox::popo::PublisherOptions publisherOptions;
+    iox::popo::PublisherPortData publisherPortData{service, namePublisher, &memoryManager, publisherOptions};
     EXPECT_THAT(m_introspectionAccess.addPublisher(&publisherPortData, namePublisher, service, nodeName), Eq(true));
 
     EXPECT_CALL(m_introspectionAccess.getPublisherPort().value(), tryAllocateChunk(_))

--- a/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
+++ b/iceoryx_posh/test/moduletests/test_roudi_port_introspection.cpp
@@ -343,10 +343,14 @@ TEST_F(PortIntrospection_test, addAndRemoveSubscriber)
 
     // test adding of ports
     // remark: duplicate subscriber insertions are possible but will not be transmitted via send
-    iox::popo::SubscriberPortData recData1{
-        service1, processName1, iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer};
-    iox::popo::SubscriberPortData recData2{
-        service2, processName2, iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer};
+    iox::popo::SubscriberPortData recData1{service1,
+                                           processName1,
+                                           iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
+                                           iox::popo::SubscriberOptions()};
+    iox::popo::SubscriberPortData recData2{service2,
+                                           processName2,
+                                           iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
+                                           iox::popo::SubscriberOptions()};
     EXPECT_THAT(m_introspectionAccess.addSubscriber(&recData1, processName1, service1, nodeName1), Eq(true));
     EXPECT_THAT(m_introspectionAccess.addSubscriber(&recData1, processName1, service1, nodeName1), Eq(true));
     EXPECT_THAT(m_introspectionAccess.addSubscriber(&recData2, processName2, service2, nodeName2), Eq(true));
@@ -463,8 +467,10 @@ TEST_F(PortIntrospection_test, reportMessageToEstablishConnection)
                                            expectedPublisher.m_caproEventMethodID);
 
     // test adding of publisher or subscriber port of same service to establish a connection (requires same service id)
-    iox::popo::SubscriberPortData recData1{
-        service, nameSubscriber, iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer};
+    iox::popo::SubscriberPortData recData1{service,
+                                           nameSubscriber,
+                                           iox::cxx::VariantQueueTypes::FiFo_MultiProducerSingleConsumer,
+                                           iox::popo::SubscriberOptions()};
     EXPECT_THAT(m_introspectionAccess.addSubscriber(&recData1, nameSubscriber, service, nodeName), Eq(true));
     iox::mepoo::MemoryManager memoryManager;
     iox::popo::PublisherPortData publisherPortData{service, namePublisher, &memoryManager};

--- a/iceoryx_posh/test/stubs/stub_gateway_generic.hpp
+++ b/iceoryx_posh/test/stubs/stub_gateway_generic.hpp
@@ -54,10 +54,11 @@ class StubbedGatewayGeneric : public TestGatewayGeneric<channel_t>
         // Stubbed.
     }
 
-    iox::cxx::expected<channel_t, iox::gw::GatewayError>
-    addChannel(const iox::capro::ServiceDescription& service) noexcept
+    template <typename IceoryxPubSubOptions>
+    iox::cxx::expected<channel_t, iox::gw::GatewayError> addChannel(const iox::capro::ServiceDescription& service,
+                                                                    const IceoryxPubSubOptions& options) noexcept
     {
-        return TestGatewayGeneric<channel_t>::addChannel(service);
+        return TestGatewayGeneric<channel_t>::addChannel(service, options);
     }
 
     iox::cxx::optional<channel_t> findChannel(const iox::capro::ServiceDescription& service) noexcept

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -611,7 +611,7 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
     iox::popo::TypedSubscriber<MemPoolIntrospectionInfoContainer> memPoolSubscriber(IntrospectionMempoolService);
     if (introspectionSelection.mempool == true)
     {
-        memPoolSubscriber.subscribe(1u);
+        memPoolSubscriber.subscribe();
 
         if (waitForSubscription(memPoolSubscriber) == false)
         {
@@ -624,7 +624,7 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
     iox::popo::TypedSubscriber<ProcessIntrospectionFieldTopic> processSubscriber(IntrospectionProcessService);
     if (introspectionSelection.process == true)
     {
-        processSubscriber.subscribe(1u);
+        processSubscriber.subscribe();
 
         if (waitForSubscription(processSubscriber) == false)
         {
@@ -642,9 +642,9 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
 
     if (introspectionSelection.port == true)
     {
-        portSubscriber.subscribe(1u);
-        portThroughputSubscriber.subscribe(1u);
-        subscriberPortChangingDataSubscriber.subscribe(1u);
+        portSubscriber.subscribe();
+        portThroughputSubscriber.subscribe();
+        subscriberPortChangingDataSubscriber.subscribe();
 
         if (waitForSubscription(portSubscriber) == false)
         {

--- a/tools/introspection/source/introspection_app.cpp
+++ b/tools/introspection/source/introspection_app.cpp
@@ -607,8 +607,13 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
     initTerminal();
     prettyPrint("### Iceoryx Introspection Client ###\n\n", PrettyOptions::title);
 
+    popo::SubscriberOptions subscriberOptions;
+    subscriberOptions.queueCapacity = 1U;
+    subscriberOptions.historyRequest = 1U;
+
     // mempool
-    iox::popo::TypedSubscriber<MemPoolIntrospectionInfoContainer> memPoolSubscriber(IntrospectionMempoolService);
+    iox::popo::TypedSubscriber<MemPoolIntrospectionInfoContainer> memPoolSubscriber(IntrospectionMempoolService,
+                                                                                    subscriberOptions);
     if (introspectionSelection.mempool == true)
     {
         memPoolSubscriber.subscribe();
@@ -621,7 +626,8 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
     }
 
     // process
-    iox::popo::TypedSubscriber<ProcessIntrospectionFieldTopic> processSubscriber(IntrospectionProcessService);
+    iox::popo::TypedSubscriber<ProcessIntrospectionFieldTopic> processSubscriber(IntrospectionProcessService,
+                                                                                 subscriberOptions);
     if (introspectionSelection.process == true)
     {
         processSubscriber.subscribe();
@@ -634,11 +640,11 @@ void IntrospectionApp::runIntrospection(const iox::units::Duration updatePeriodM
     }
 
     // port
-    iox::popo::TypedSubscriber<PortIntrospectionFieldTopic> portSubscriber(IntrospectionPortService);
+    iox::popo::TypedSubscriber<PortIntrospectionFieldTopic> portSubscriber(IntrospectionPortService, subscriberOptions);
     iox::popo::TypedSubscriber<PortThroughputIntrospectionFieldTopic> portThroughputSubscriber(
-        IntrospectionPortThroughputService);
+        IntrospectionPortThroughputService, subscriberOptions);
     iox::popo::TypedSubscriber<SubscriberPortChangingIntrospectionFieldTopic> subscriberPortChangingDataSubscriber(
-        IntrospectionSubscriberPortChangingDataService);
+        IntrospectionSubscriberPortChangingDataService, subscriberOptions);
 
     if (introspectionSelection.port == true)
     {


### PR DESCRIPTION
## Pre-Review Checklist for the PR Author

1. [x] Branch follows the naming format (`iox-#123-this-is-a-branch`)
1. [x] Commits messages are according to this [guideline][commit-guidelines]
    - [x] Commit messages have the issue ID (`iox-#123 commit text`)
    - [x] Commit messages are signed (`git commit -s`)
    - [x] Commit author matches [Eclipse Contributor Agreement][eca] (and ECA is signed)
1. [x] Update the PR title
   - Follow the same conventions as for commit messages
   - Link to the relevant issue
1. [x] Relevant issues are linked
1. [x] Add sensible notes for the reviewer
1. [x] All checks have passed
1. [x] Assign PR to reviewer

[commit-guidelines]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
[eca]: http://www.eclipse.org/legal/ECA.php

## Notes for Reviewer
This is a follow up to #441 and  and based on the branch from that PR. It adds a `SubscriberOptions` struct to configure `historyRequest` and `queueCapacity`. Documentation and examples will be updated in the next PR.
Please wait with review until #441 is merged.

## Checklist for the PR Reviewer

- [x] Commits are properly organized and messages are according to the guideline
- [x] Code according to our coding style and naming conventions
- [x] Unit tests have been written for new behavior
- [x] Public API changes are documented via doxygen
- [x] Copyright owner are updated in the changed files
- [x] PR title describes the changes

## Post-review Checklist for the PR Author

1. [x] All open points are addressed and tracked via issues

## Post-review Checklist for the Eclipse Committer

1. [x] All checkboxes in the PR checklist are checked or crossed out
1. [x] Merge

## References

- Partly closes #408 
